### PR TITLE
Fix out of bounds access in face-{cuda/hip}

### DIFF
--- a/src/face-cuda/image.cu
+++ b/src/face-cuda/image.cu
@@ -241,7 +241,7 @@ void createSumImage(int width, int height, MyIntImage *image)
   image->width = width;
   image->height = height;
   image->flag = 1;
-  image->data = (int *)malloc(sizeof(int)*(height*width));
+  image->data = (int *)calloc((size_t)(height + 1) * (width + 1), sizeof(int));
 }
 
 int freeImage(MyImage* image)


### PR DESCRIPTION
Add extra row and column to the allocation to prevent out of bounds access.

Fixes #165.