### PR TITLE
[lut-gemm-hip] Fix uninitialized read

### DIFF
--- a/src/lut-gemm-hip/nQWeight_fp16.cu
+++ b/src/lut-gemm-hip/nQWeight_fp16.cu
@@ -22,7 +22,6 @@
 void nQWeight_fp16::parsing(unsigned int *bW, float *A, int row, int col, int num_bits, 
         bool is_row_wise_quantize, int num_alpha_groups, float* q_bias){
     this->num_groups = num_alpha_groups;
-    this->group_size =  kSize/num_alpha_groups;
 
     __half* p_alpha;
     __half* p_q_bias;
@@ -36,6 +35,7 @@ void nQWeight_fp16::parsing(unsigned int *bW, float *A, int row, int col, int nu
         mSize = col; 
         kSize = row;             
     }
+    this->group_size =  kSize/num_alpha_groups;
 
     if(q_bias == nullptr) p_q_bias = nullptr;
     else{


### PR DESCRIPTION
`kSize` is not initialized in the default constructor, so until either line 33 or 37, it's not initialized. 