### PR TITLE
[rsmt-hip] Add support for warpsize/wavefrontsize 64

### DIFF
--- a/src/rsmt-hip/main.cu
+++ b/src/rsmt-hip/main.cu
@@ -146,13 +146,13 @@ bool insertSteinerPoints(ID& num,
         }
       }
     }
-    const int bal = __ballot(insert);
-    const int pos = __popc(bal & ~(-1 << lane)) + num;
+    const ballot_t bal = __ballot(insert);
+    const int pos = popc_ballot(bal & ~((ballot_t)(-1) << lane)) + num;
     if (insert) {
       x[pos] = stx;
       y[pos] = sty;
     }
-    num += __popc(bal);
+    num += popc_ballot(bal);
   }
 
   return __any(updated);
@@ -322,7 +322,7 @@ static void computeRSMT(const int* const __restrict__ idxin,
   hipMemset(d_yout, -1, 2 * size * sizeof(ctype));
   hipMemset(d_edges, 0, 2 * size * sizeof(edge));
 
-  largeNetKernel<24, 64><<<blocks, 24 * WS>>>(d_idxin, d_xin, d_yin, d_idxout, d_xout, d_yout, d_edges, numnets, d_wl);
+  largeNetKernel<LargeNetWPB, 64><<<blocks, LargeNetWPB * WS>>>(d_idxin, d_xin, d_yin, d_idxout, d_xout, d_yout, d_edges, numnets, d_wl);
   smallNetKernel<3, 512><<<blocks, 3 * WS>>>(d_idxin, d_xout, d_yout, d_edges, d_wl);
 
   // end time

--- a/src/rsmt-hip/utils.h
+++ b/src/rsmt-hip/utils.h
@@ -7,7 +7,20 @@
 #include <climits>
 
 static const int MaxPins = 256;  // must be a power of 2
-static const int WS = 32;  // warp size
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
+static const int WS = 64;  // AMD CDNA wavefront size
+using ballot_t = unsigned long long;
+__device__ inline int popc_ballot(unsigned long long x) { return __popcll(x); }
+#else
+static const int WS = 32;  // NVIDIA warp size
+using ballot_t = unsigned int;
+__device__ inline int popc_ballot(unsigned int x) { return __popc(x); }
+#endif
+
+// Number of wavefronts/warps per block for largeNetKernel; keeps total
+// thread count at 768 regardless of WS (24*32 on NVIDIA, 12*64 on AMD).
+static const int LargeNetWPB = 768 / WS;
 
 using ID = short;  // must be signed (point and edge IDs)
 using ctype = int;  // must be signed (coordinates and distances)  // change requires further change below


### PR DESCRIPTION
Adapt warpsize/wavefrontsize to the underlying hardware, and add support for warpsize/wavefrontsize 64.

Fixes #171.

Assisted by: Claude Code.