### PR TITLE
[opticalFlow-hip] Replace hipResourceTypePitch2D with hipResourceTypeArray

### DIFF
--- a/src/opticalFlow-hip/derivativesKernel.cuh
+++ b/src/opticalFlow-hip/derivativesKernel.cuh
@@ -107,28 +107,55 @@ static void ComputeDerivatives(const float *I0, const float *I1, int w, int h,
   dim3 threads(32, 6);
   dim3 blocks(iDivUp(w, threads.x), iDivUp(h, threads.y));
 
-  hipTextureObject_t texSource, texTarget;
-  hipResourceDesc texRes;
-  memset(&texRes, 0, sizeof(hipResourceDesc));
-
-  texRes.resType = hipResourceTypePitch2D;
-  texRes.res.pitch2D.devPtr = (void *)I0;
-  texRes.res.pitch2D.desc = hipCreateChannelDesc<float>();
-  texRes.res.pitch2D.width = w;
-  texRes.res.pitch2D.height = h;
-  texRes.res.pitch2D.pitchInBytes = s * sizeof(float);
-
   hipTextureDesc texDescr;
   memset(&texDescr, 0, sizeof(hipTextureDesc));
-
   texDescr.normalizedCoords = true;
   texDescr.filterMode = hipFilterModeLinear;
   texDescr.addressMode[0] = hipAddressModeMirror;
   texDescr.addressMode[1] = hipAddressModeMirror;
   texDescr.readMode = hipReadModeElementType;
 
+  hipTextureObject_t texSource, texTarget;
+  hipResourceDesc texRes;
+
+#ifdef __HIP_PLATFORM_AMD__
+  // AMD: Pitch2D + normalizedCoords/linear filter is unsupported; stage into hipArrays
+  hipChannelFormatDesc channelDesc = hipCreateChannelDesc<float>();
+
+  hipArray_t sourceArray, targetArray;
+  checkCudaErrors(hipMallocArray(&sourceArray, &channelDesc, w, h));
+  checkCudaErrors(hipMemcpy2DToArray(sourceArray, 0, 0, I0,
+                                     s * sizeof(float),
+                                     w * sizeof(float), h,
+                                     hipMemcpyDeviceToDevice));
+  checkCudaErrors(hipMallocArray(&targetArray, &channelDesc, w, h));
+  checkCudaErrors(hipMemcpy2DToArray(targetArray, 0, 0, I1,
+                                     s * sizeof(float),
+                                     w * sizeof(float), h,
+                                     hipMemcpyDeviceToDevice));
+
+  memset(&texRes, 0, sizeof(hipResourceDesc));
+  texRes.resType = hipResourceTypeArray;
+  texRes.res.array.array = sourceArray;
   checkCudaErrors(
       hipCreateTextureObject(&texSource, &texRes, &texDescr, NULL));
+
+  memset(&texRes, 0, sizeof(hipResourceDesc));
+  texRes.resType = hipResourceTypeArray;
+  texRes.res.array.array = targetArray;
+  checkCudaErrors(
+      hipCreateTextureObject(&texTarget, &texRes, &texDescr, NULL));
+#else
+  memset(&texRes, 0, sizeof(hipResourceDesc));
+  texRes.resType = hipResourceTypePitch2D;
+  texRes.res.pitch2D.devPtr = (void *)I0;
+  texRes.res.pitch2D.desc = hipCreateChannelDesc<float>();
+  texRes.res.pitch2D.width = w;
+  texRes.res.pitch2D.height = h;
+  texRes.res.pitch2D.pitchInBytes = s * sizeof(float);
+  checkCudaErrors(
+      hipCreateTextureObject(&texSource, &texRes, &texDescr, NULL));
+
   memset(&texRes, 0, sizeof(hipResourceDesc));
   texRes.resType = hipResourceTypePitch2D;
   texRes.res.pitch2D.devPtr = (void *)I1;
@@ -138,7 +165,15 @@ static void ComputeDerivatives(const float *I0, const float *I1, int w, int h,
   texRes.res.pitch2D.pitchInBytes = s * sizeof(float);
   checkCudaErrors(
       hipCreateTextureObject(&texTarget, &texRes, &texDescr, NULL));
+#endif
 
   ComputeDerivativesKernel<<<blocks, threads>>>(w, h, s, Ix, Iy, Iz, texSource,
                                                 texTarget);
+
+  checkCudaErrors(hipDestroyTextureObject(texSource));
+  checkCudaErrors(hipDestroyTextureObject(texTarget));
+#ifdef __HIP_PLATFORM_AMD__
+  checkCudaErrors(hipFreeArray(sourceArray));
+  checkCudaErrors(hipFreeArray(targetArray));
+#endif
 }

--- a/src/opticalFlow-hip/downscaleKernel.cuh
+++ b/src/opticalFlow-hip/downscaleKernel.cuh
@@ -71,16 +71,28 @@ static void Downscale(const float *src, int width, int height, int stride,
   dim3 threads(32, 8);
   dim3 blocks(iDivUp(newWidth, threads.x), iDivUp(newHeight, threads.y));
 
-  hipTextureObject_t texFine;
   hipResourceDesc texRes;
   memset(&texRes, 0, sizeof(hipResourceDesc));
 
+#ifdef __HIP_PLATFORM_AMD__
+  // AMD: Pitch2D + normalizedCoords/linear filter is unsupported; stage into a hipArray
+  hipChannelFormatDesc channelDesc = hipCreateChannelDesc<float>();
+  hipArray_t srcArray;
+  checkCudaErrors(hipMallocArray(&srcArray, &channelDesc, width, height));
+  checkCudaErrors(hipMemcpy2DToArray(srcArray, 0, 0, src,
+                                     stride * sizeof(float),
+                                     width * sizeof(float), height,
+                                     hipMemcpyDeviceToDevice));
+  texRes.resType = hipResourceTypeArray;
+  texRes.res.array.array = srcArray;
+#else
   texRes.resType = hipResourceTypePitch2D;
   texRes.res.pitch2D.devPtr = (void *)src;
   texRes.res.pitch2D.desc = hipCreateChannelDesc<float>();
   texRes.res.pitch2D.width = width;
   texRes.res.pitch2D.height = height;
   texRes.res.pitch2D.pitchInBytes = stride * sizeof(float);
+#endif
 
   hipTextureDesc texDescr;
   memset(&texDescr, 0, sizeof(hipTextureDesc));
@@ -91,8 +103,14 @@ static void Downscale(const float *src, int width, int height, int stride,
   texDescr.addressMode[1] = hipAddressModeMirror;
   texDescr.readMode = hipReadModeElementType;
 
+  hipTextureObject_t texFine;
   checkCudaErrors(hipCreateTextureObject(&texFine, &texRes, &texDescr, NULL));
 
   DownscaleKernel<<<blocks, threads>>>(newWidth, newHeight, newStride, out,
                                        texFine);
+
+  checkCudaErrors(hipDestroyTextureObject(texFine));
+#ifdef __HIP_PLATFORM_AMD__
+  checkCudaErrors(hipFreeArray(srcArray));
+#endif
 }

--- a/src/opticalFlow-hip/upscaleKernel.cuh
+++ b/src/opticalFlow-hip/upscaleKernel.cuh
@@ -68,16 +68,28 @@ static void Upscale(const float *src, int width, int height, int stride,
   dim3 threads(32, 8);
   dim3 blocks(iDivUp(newWidth, threads.x), iDivUp(newHeight, threads.y));
 
-  hipTextureObject_t texCoarse;
   hipResourceDesc texRes;
   memset(&texRes, 0, sizeof(hipResourceDesc));
 
+#ifdef __HIP_PLATFORM_AMD__
+  // AMD: Pitch2D + normalizedCoords/linear filter is unsupported; stage into a hipArray
+  hipChannelFormatDesc channelDesc = hipCreateChannelDesc<float>();
+  hipArray_t srcArray;
+  checkCudaErrors(hipMallocArray(&srcArray, &channelDesc, width, height));
+  checkCudaErrors(hipMemcpy2DToArray(srcArray, 0, 0, src,
+                                     stride * sizeof(float),
+                                     width * sizeof(float), height,
+                                     hipMemcpyDeviceToDevice));
+  texRes.resType = hipResourceTypeArray;
+  texRes.res.array.array = srcArray;
+#else
   texRes.resType = hipResourceTypePitch2D;
   texRes.res.pitch2D.devPtr = (void *)src;
   texRes.res.pitch2D.desc = hipCreateChannelDesc<float>();
   texRes.res.pitch2D.width = width;
   texRes.res.pitch2D.height = height;
   texRes.res.pitch2D.pitchInBytes = stride * sizeof(float);
+#endif
 
   hipTextureDesc texDescr;
   memset(&texDescr, 0, sizeof(hipTextureDesc));
@@ -88,9 +100,15 @@ static void Upscale(const float *src, int width, int height, int stride,
   texDescr.addressMode[1] = hipAddressModeMirror;
   texDescr.readMode = hipReadModeElementType;
 
+  hipTextureObject_t texCoarse;
   checkCudaErrors(
       hipCreateTextureObject(&texCoarse, &texRes, &texDescr, NULL));
 
   UpscaleKernel<<<blocks, threads>>>(newWidth, newHeight, newStride, scale, out,
                                      texCoarse);
+
+  checkCudaErrors(hipDestroyTextureObject(texCoarse));
+#ifdef __HIP_PLATFORM_AMD__
+  checkCudaErrors(hipFreeArray(srcArray));
+#endif
 }

--- a/src/opticalFlow-hip/warpingKernel.cuh
+++ b/src/opticalFlow-hip/warpingKernel.cuh
@@ -73,16 +73,28 @@ static void WarpImage(const float *src, int w, int h, int s, const float *u,
   dim3 threads(32, 6);
   dim3 blocks(iDivUp(w, threads.x), iDivUp(h, threads.y));
 
-  hipTextureObject_t texToWarp;
   hipResourceDesc texRes;
   memset(&texRes, 0, sizeof(hipResourceDesc));
 
+#ifdef __HIP_PLATFORM_AMD__
+  // AMD: Pitch2D + normalizedCoords/linear filter is unsupported; stage into a hipArray
+  hipChannelFormatDesc channelDesc = hipCreateChannelDesc<float>();
+  hipArray_t srcArray;
+  checkCudaErrors(hipMallocArray(&srcArray, &channelDesc, w, h));
+  checkCudaErrors(hipMemcpy2DToArray(srcArray, 0, 0, src,
+                                     s * sizeof(float),
+                                     w * sizeof(float), h,
+                                     hipMemcpyDeviceToDevice));
+  texRes.resType = hipResourceTypeArray;
+  texRes.res.array.array = srcArray;
+#else
   texRes.resType = hipResourceTypePitch2D;
   texRes.res.pitch2D.devPtr = (void *)src;
   texRes.res.pitch2D.desc = hipCreateChannelDesc<float>();
   texRes.res.pitch2D.width = w;
   texRes.res.pitch2D.height = h;
   texRes.res.pitch2D.pitchInBytes = s * sizeof(float);
+#endif
 
   hipTextureDesc texDescr;
   memset(&texDescr, 0, sizeof(hipTextureDesc));
@@ -93,8 +105,14 @@ static void WarpImage(const float *src, int w, int h, int s, const float *u,
   texDescr.addressMode[1] = hipAddressModeMirror;
   texDescr.readMode = hipReadModeElementType;
 
+  hipTextureObject_t texToWarp;
   checkCudaErrors(
       hipCreateTextureObject(&texToWarp, &texRes, &texDescr, NULL));
 
   WarpingKernel<<<blocks, threads>>>(w, h, s, u, v, out, texToWarp);
+
+  checkCudaErrors(hipDestroyTextureObject(texToWarp));
+#ifdef __HIP_PLATFORM_AMD__
+  checkCudaErrors(hipFreeArray(srcArray));
+#endif
 }


### PR DESCRIPTION
Fixes #190.

Assisted by: Claude Code.