### PR TITLE
Make MPI paths overridable via environment in HIP benchmarks

### DIFF
--- a/src/allreduce-hip/Makefile
+++ b/src/allreduce-hip/Makefile
@@ -6,11 +6,9 @@
 CC        = hipcc
 OPTIMIZE  = yes
 DEBUG     = no
-MPI_ROOT  = $(HOME)/ompi_for_gpu/ompi
-LAUNCHER  = $(HOME)/ompi_for_gpu/ompi/bin/mpirun -n 2
+MPI_ROOT ?= /usr/lib/x86_64-linux-gnu/openmpi
+LAUNCHER ?= /usr/bin/mpirun -n 2
 
-#MPI_ROOT  = /usr/lib/x86_64-linux-gnu/openmpi
-#LAUNCHER  = /usr/bin/mpirun -n 1
 
 #===============================================================================
 # Program name & source code list

--- a/src/ccl-hip/Makefile
+++ b/src/ccl-hip/Makefile
@@ -6,9 +6,8 @@
 CC        = hipcc
 OPTIMIZE  = yes
 DEBUG     = no
-MPI_ROOT  = $(HOME)/ompi_for_gpu/ompi
-LAUNCHER  = $(HOME)/ompi_for_gpu/ompi/bin/mpirun --mca pml ucx --mca osc ucx \
-            --mca coll_ucc_enable 1 --mca coll_ucc_priority 100 -n 2
+MPI_ROOT ?= /usr/lib/x86_64-linux-gnu/openmpi
+LAUNCHER ?= /usr/bin/mpirun -n 2
 
 #===============================================================================
 # Program name & source code list

--- a/src/halo-finder-hip/Makefile
+++ b/src/halo-finder-hip/Makefile
@@ -1,7 +1,7 @@
 HIPCC_BIN=/opt/rocm/bin
 
 # the path may be adjusted for each platform
-MPI_INCLUDE=/usr/lib/x86_64-linux-gnu/openmpi/include
+MPI_INCLUDE ?= /usr/lib/x86_64-linux-gnu/openmpi/include
 
 OPT=-O3 -DRCB_UNTHREADED_BUILD -DUSE_SERIAL_COSMO
 

--- a/src/miniWeather-hip/Makefile
+++ b/src/miniWeather-hip/Makefile
@@ -6,8 +6,8 @@
 CC        = hipcc
 OPTIMIZE  = yes
 DEBUG     = no
-MPI_INCLUDE = "/usr/lib/x86_64-linux-gnu/openmpi/include"
-MPI_LIB_DIR = "/usr/lib/x86_64-linux-gnu/openmpi/lib"
+MPI_INCLUDE ?= "/usr/lib/x86_64-linux-gnu/openmpi/include"
+MPI_LIB_DIR ?= "/usr/lib/x86_64-linux-gnu/openmpi/lib"
 LAUNCHER    =
 
 #===============================================================================

--- a/src/pingpong-hip/Makefile
+++ b/src/pingpong-hip/Makefile
@@ -6,10 +6,8 @@
 CC        = hipcc
 OPTIMIZE  = yes
 DEBUG     = no
-MPI_ROOT  = /usr/lib/x86_64-linux-gnu/openmpi
-LAUNCHER  = /usr/bin/mpirun -n 2
-#MPI_ROOT  = $(HOME)/ompi_for_gpu/ompi
-#LAUNCHER  = $(HOME)/ompi_for_gpu/ompi/bin/mpirun -n 2
+MPI_ROOT ?= /usr/lib/x86_64-linux-gnu/openmpi
+LAUNCHER ?= /usr/bin/mpirun -n 2
 
 #===============================================================================
 # Program name & source code list

--- a/src/sparkler-hip/Makefile
+++ b/src/sparkler-hip/Makefile
@@ -1,16 +1,16 @@
 #===============================================================================
 # User Options
 #===============================================================================
-MPI_ROOT=$(HOME)/openmpi-4.1.0-install/
+MPI_ROOT ?= /usr/lib/x86_64-linux-gnu/openmpi
 HIPBLAS_ROOT=/opt/rocm/hipblas
 HIPRT_ROOT=/opt/rocm/hip
 
 # Compiler can be set below, or via environment variable
 CC        = hipcc
-LD        = $(MPI_ROOT)/bin/mpiCC
+LD       ?= mpiCC
 OPTIMIZE  = yes
 DEBUG     = no
-LAUNCHER  =
+LAUNCHER ?=
 
 #===============================================================================
 # Program name & source code list
@@ -59,4 +59,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) $(MPI_ROOT)/bin/mpirun -n 4 ./$(program) --num_vector 4000 --num_field 90000 --num_iterations 10
+	$(LAUNCHER) mpirun -n 4 ./$(program) --num_vector 4000 --num_field 90000 --num_iterations 10


### PR DESCRIPTION
## Summary

Six HIP benchmarks reference MPI in their Makefiles: `allreduce`, `ccl`,
`halo-finder`, `miniWeather`, `pingpong`, `sparkler`. Three of them
(`allreduce`, `ccl`, `sparkler`) currently hardcode their MPI install path to
locations that only exist on a particular developer's machine:

```make
MPI_ROOT  = $(HOME)/ompi_for_gpu/ompi              # allreduce, ccl
MPI_ROOT  = $(HOME)/openmpi-4.1.0-install/         # sparkler
```

These benchmarks fail to build on any system without that exact directory
layout, requiring users to edit the Makefiles by hand.

This PR makes the MPI paths overridable via environment / command-line:

1. Switches MPI-related Makefile assignments (`MPI_ROOT`, `MPI_INCLUDE`,
   `MPI_LIB_DIR`, `LAUNCHER`, and `sparkler`'s `LD`) from `=` to `?=` so
   environment variables and `make VAR=...` overrides take effect.
2. Updates the broken defaults to point at the standard Debian/Ubuntu
   OpenMPI install — `/usr/lib/x86_64-linux-gnu/openmpi` — matching the
   default `pingpong-hip` already uses.
3. For `sparkler-hip`: replaces `$(MPI_ROOT)/bin/mpiCC` and
   `$(MPI_ROOT)/bin/mpirun` with bare `mpiCC` / `mpirun` (relying on PATH).
   The Debian/Ubuntu OpenMPI package places binaries in `/usr/bin/` rather
   than under MPI_ROOT, so `$(MPI_ROOT)/bin/...` does not work with the new
   default.

After this PR, all six MPI-using HIP benchmarks compile out of the box on
a stock Debian/Ubuntu system with `libopenmpi-dev` installed, with no
Makefile edits needed.

## Behavior preservation

Existing CI environments where the previous defaults were valid keep
working — users only need to point their environment at the install:

```sh
# Custom MPI install:
MPI_ROOT=$HOME/ompi_for_gpu/ompi \
LAUNCHER="$HOME/ompi_for_gpu/ompi/bin/mpirun -n 2" \
make
```

This matches the convention several other HeCBench Makefiles already use
(e.g. `pingpong-hip` uses `MPI_ROOT` with a system default; many
non-MPI Makefiles use `?=` for similar tunables).

The `ccl-hip` Makefile previously included UCX-specific `--mca` flags in
its hardcoded `LAUNCHER`. These are dropped from the default because
default OpenMPI builds do not have UCX/UCC enabled. Users with a
UCX-aware OpenMPI install can restore the flags via `LAUNCHER='mpirun
--mca pml ucx --mca osc ucx --mca coll_ucc_enable 1 -n 2'`.