### PR TITLE
[gerbil-hip] Update GPU macro in Makefile to avoid collisions

### DIFF
--- a/src/gerbil-hip/Makefile
+++ b/src/gerbil-hip/Makefile
@@ -37,12 +37,12 @@ obj = AddKernel.o        \
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -fpermissive -DGPU \
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -fpermissive -DGERBIL_USE_GPU \
 	  -DBOOST_ALL_NO_LIB -DBOOST_ATOMIC_DYN_LINK -DBOOST_FILESYSTEM_DYN_LINK \
           -DBOOST_REGEX_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DBOOST_THREAD_DYN_LINK \
 	  -I/opt/rocm/include -D__HIP_PLATFORM_AMD__
 
-HIPCCFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -DGPU
+HIPCCFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -DGERBIL_USE_GPU
 
 # Linker Flags
 LDFLAGS = -lboost_system -lboost_thread -lboost_regex -lboost_filesystem \


### PR DESCRIPTION
Follow up of #196. My previous patch was missing updating the variable definition in the Makefile.