### PR TITLE
[sparkler-hip] Make HIP libs paths overridable via environment

### DIFF
--- a/src/sparkler-hip/Makefile
+++ b/src/sparkler-hip/Makefile
@@ -2,8 +2,9 @@
 # User Options
 #===============================================================================
 MPI_ROOT=$(HOME)/openmpi-4.1.0-install/
-HIPBLAS_ROOT=/opt/rocm/hipblas
-HIPRT_ROOT=/opt/rocm/hip
+ROCM_PATH    ?= /opt/rocm
+HIPBLAS_ROOT ?= $(ROCM_PATH)
+HIPRT_ROOT   ?= $(ROCM_PATH)
 
 # Compiler can be set below, or via environment variable
 CC        = hipcc


### PR DESCRIPTION
By using `?=` the variables can be overriden via environment. Also, the hardcoded /opt/rocm/hipblas and /opt/rocm/hip paths reflect the pre-5.x ROCm subdirectory layout. Modern ROCm and alternative dists (e.g. TheRock) install hipblas and amdhip64 directly under $(ROCM_PATH)/lib.