### PR TITLE
[hpl-hip] Make LAdir env overridable

### DIFF
--- a/src/hpl-hip/src/hpl-2.3/Make.intel64
+++ b/src/hpl-hip/src/hpl-2.3/Make.intel64
@@ -139,7 +139,7 @@ MPlib        = -lmpi #$(MPdir)/lib/release/libmpi.so
 # header files,  LAlib  is defined  to be the name of  the library to be
 # used. The variable LAdir is only used for defining LAinc and LAlib.
 #
-LAdir        = $(HOME)/lapack/build_lapack_32
+LAdir        ?= $(HOME)/lapack/build_lapack_32
 LAinc        = -I$(LAdir)/include -I$(TOPdir)/src/cuda/
 LAlib 	     = -L$(TOPdir)/src/cuda/ -ldgemm \
 		-L$(LAdir)/lib/ -lcblas \


### PR DESCRIPTION
Switch LAdir from `=` to `?=` so users who built LAPACK outside $HOME (system
package, shared workspace, CI cache) can override via environment without
patching Make.intel64.