### PR TITLE
[slu-cuda,slu-hip] Auto-extract NICSLU at build time

### DIFF
--- a/src/slu-cuda/src/Makefile
+++ b/src/slu-cuda/src/Makefile
@@ -70,15 +70,27 @@ main.o: $(SLU_PATH)/main.cpp
 preprocess.o: $(SLU_PATH)/preprocess.cpp
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(SLU_PATH)/nicslu/lib/nicslu.a:
-	make -C $(SLU_PATH)/nicslu/
+# Auto-extract NICSLU on first build (or if a previous extraction was
+# incomplete). nicslu/Makefile is the sentinel — make treats the extracted
+# tree as an output of the tarball.
+$(SLU_PATH)/nicslu/Makefile: $(SLU_PATH)/nicslu.tar.bz2
+	@if [ ! -f $(SLU_PATH)/nicslu/include/nicslu.h ] || \
+	    [ ! -d $(SLU_PATH)/nicslu/source ]; then \
+		echo "Extracting NICSLU..."; \
+		rm -rf $(SLU_PATH)/nicslu; \
+		tar -xjf $(SLU_PATH)/nicslu.tar.bz2 -C $(SLU_PATH); \
+	fi
 
-$(SLU_PATH)/nicslu/util/nicslu_util.a:
-	make -C $(SLU_PATH)/nicslu/
+$(SLU_PATH)/nicslu/lib/nicslu.a: $(SLU_PATH)/nicslu/Makefile
+	$(MAKE) -C $(SLU_PATH)/nicslu/
+
+$(SLU_PATH)/nicslu/util/nicslu_util.a: $(SLU_PATH)/nicslu/Makefile
+	$(MAKE) -C $(SLU_PATH)/nicslu/
 
 clean:
 	rm -rf $(program) $(obj) *.dat
-	make -C $(SLU_PATH)/nicslu/ clean
+	@[ -f $(SLU_PATH)/nicslu/Makefile ] && \
+		$(MAKE) -C $(SLU_PATH)/nicslu/ clean || true
 
 test: $(program)
 	$(LAUNCHER) ./$(program) -i $(SLU_PATH)/nicslu/test/add32.mtx

--- a/src/slu-cuda/src/README
+++ b/src/slu-cuda/src/README
@@ -1,2 +1,1 @@
-Please uncompress the file, nicslu.tar.bz2, before building the application.
-
+The NICSLU library (nicslu.tar.bz2) is auto-extracted by the Makefile on first build.

--- a/src/slu-hip/Makefile
+++ b/src/slu-hip/Makefile
@@ -70,15 +70,27 @@ main.o: $(SLU_PATH)/main.cpp
 preprocess.o: $(SLU_PATH)/preprocess.cpp
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(SLU_PATH)/nicslu/lib/nicslu.a:
-	make -C $(SLU_PATH)/nicslu/
+# Auto-extract NICSLU on first build (or if a previous extraction was
+# incomplete). nicslu/Makefile is the sentinel — make treats the extracted
+# tree as an output of the tarball.
+$(SLU_PATH)/nicslu/Makefile: $(SLU_PATH)/nicslu.tar.bz2
+	@if [ ! -f $(SLU_PATH)/nicslu/include/nicslu.h ] || \
+	    [ ! -d $(SLU_PATH)/nicslu/source ]; then \
+		echo "Extracting NICSLU..."; \
+		rm -rf $(SLU_PATH)/nicslu; \
+		tar -xjf $(SLU_PATH)/nicslu.tar.bz2 -C $(SLU_PATH); \
+	fi
 
-$(SLU_PATH)/nicslu/util/nicslu_util.a:
-	make -C $(SLU_PATH)/nicslu/
+$(SLU_PATH)/nicslu/lib/nicslu.a: $(SLU_PATH)/nicslu/Makefile
+	$(MAKE) -C $(SLU_PATH)/nicslu/
+
+$(SLU_PATH)/nicslu/util/nicslu_util.a: $(SLU_PATH)/nicslu/Makefile
+	$(MAKE) -C $(SLU_PATH)/nicslu/
 
 clean:
 	rm -rf $(program) $(obj) *.dat
-	make -C $(SLU_PATH)/nicslu/ clean
+	@[ -f $(SLU_PATH)/nicslu/Makefile ] && \
+		$(MAKE) -C $(SLU_PATH)/nicslu/ clean || true
 
 test: $(program)
 	$(LAUNCHER) ./$(program) -i $(SLU_PATH)/nicslu/test/add32.mtx

--- a/src/slu-hip/README
+++ b/src/slu-hip/README
@@ -1,2 +1,1 @@
-Please uncompress the file "nicslu.tar.bz2" located in ../slu-cuda/src before building the application.
-
+The NICSLU library (../slu-cuda/src/nicslu.tar.bz2) is auto-extracted by the Makefile on first build.


### PR DESCRIPTION
The NICSLU third-party library is shipped as nicslu.tar.bz2 and the README instructs the user to uncompress it before building. This is a manual step that's easy to forget and yields a confusing missing-file error deep in the build when missed.

Add a Makefile rule that extracts the tarball on first build, with a validation guard so an incomplete previous extraction is detected and re-done from scratch (this has happened in the wild). Update the READMEs accordingly. The third-party-boundary intent of keeping NICSLU as a tarball is preserved — we just automate the unpack step.