### PR TITLE
[sparkler-hip] Fix LD assignment

### DIFF
--- a/src/sparkler-hip/Makefile
+++ b/src/sparkler-hip/Makefile
@@ -8,7 +8,7 @@ HIPRT_ROOT   ?= $(ROCM_PATH)
 
 # Compiler can be set below, or via environment variable
 CC        = hipcc
-LD       ?= mpiCC
+LD        = mpiCC
 OPTIMIZE  = yes
 DEBUG     = no
 LAUNCHER ?=


### PR DESCRIPTION
Fix for a bug introduced in #203 . LD is a Make-built-in variable with default value ld. `?=` only assigns if the variable is undefined, and Make has already defined `LD=ld` before our line is even read. So `LD ?= mpiCC` effectively becomes a no-op, and the wrong linker is chosen. 