### PR TITLE
[halo-finder-hip] Use explicit archive rules and add dims-local prereq

### DIFF
--- a/src/halo-finder-hip/Makefile
+++ b/src/halo-finder-hip/Makefile
@@ -118,11 +118,20 @@ $(OBJDIR)/%.o: %.cu | $(OBJDIR)
 dims-local.c: dfft/dims.c
 	cp -f dfft/dims.c dims-local.c
 
+# Explicit prerequisite: dims-local.o needs dims-local.c to be generated first.
+# Without this, 'make -j' can attempt to compile the object before 'cp' runs.
+$(OBJDIR)/dims-local.o: dims-local.c
+
 
 $(OBJDIR)/ForceTreeTest: $(OBJDIR)/ForceTreeTest.o $(OBJDIR)/libparticle.a $(OBJDIR)/libBHForceTree.a $(OBJDIR)/libpartition.a $(OBJDIR)/libhalotime.a $(OBJDIR)/libbigchunk.a $(OBJDIR)/dims-local.o
 	${HACC_MPI_CXX} -o $@ $^ ${CXXFLAGS} ${LDFLAGS} -DUSE_SERIAL_COSMO=1
 
-$(OBJDIR)/libpartition.a: $(OBJDIR)/libpartition.a($(OBJDIR)/Partition.o)
+# Use explicit object lists + ar/ranlib instead of the deprecated
+# archive(member.o) syntax. The latter triggers Make's built-in .c.o and .o.a
+# implicit rules (which call cc), bypassing this project's hipcc recipe and
+# mis-compiling the objects.
+$(OBJDIR)/libpartition.a: $(OBJDIR)/Partition.o
+	ar rv $@ $(OBJDIR)/Partition.o
 	ranlib $@
 
 
@@ -132,7 +141,8 @@ PARTICLE_SOURCES += InitialExchange.cxx
 PARTICLE_SOURCES += Message.cxx
 PARTICLE_OBJLIST = $(PARTICLE_SOURCES:.cxx=.o)
 PARTICLE_OBJECTS := $(addprefix $(OBJDIR)/,$(PARTICLE_OBJLIST))
-$(OBJDIR)/libparticle.a: $(OBJDIR)/libparticle.a($(PARTICLE_OBJECTS))
+$(OBJDIR)/libparticle.a: $(PARTICLE_OBJECTS)
+	ar rv $@ $(PARTICLE_OBJECTS)
 	ranlib $@
 
 
@@ -140,7 +150,8 @@ HT_SOURCES += Timings.cxx
 HT_SOURCES += Timer.cxx
 HT_OBJLIST = $(HT_SOURCES:.cxx=.o)
 HT_OBJECTS := $(addprefix $(OBJDIR)/,$(HT_OBJLIST))
-$(OBJDIR)/libhalotime.a: $(OBJDIR)/libhalotime.a($(HT_OBJECTS))
+$(OBJDIR)/libhalotime.a: $(HT_OBJECTS)
+	ar rv $@ $(HT_OBJECTS)
 	ranlib $@
 
 
@@ -153,14 +164,21 @@ FORCE_SOURCES_C += BGQStep16.c
 FORCE_OBJLIST = $(FORCE_SOURCES:.cxx=.o)
 FORCE_OBJLIST_C = $(FORCE_SOURCES_C:.c=.o)
 FORCE_OBJECTS := $(addprefix $(OBJDIR)/,$(FORCE_OBJLIST) $(FORCE_OBJLIST_C))
-$(OBJDIR)/libBHForceTree.a: $(OBJDIR)/libBHForceTree.a($(FORCE_OBJECTS) $(FORCE_OBJLIST_C))
+# Note: $(FORCE_OBJLIST_C) is already a subset of $(FORCE_OBJECTS) (added via
+# addprefix above) — listing it again as a separate prerequisite causes Make
+# to try its implicit cc rule for those objects.
+$(OBJDIR)/libBHForceTree.a: $(FORCE_OBJECTS)
+	ar rv $@ $(FORCE_OBJECTS)
 	ranlib $@
 
-$(OBJDIR)/libbigchunk.a: $(OBJDIR)/libbigchunk.a($(OBJDIR)/bigchunk.o)
+$(OBJDIR)/libbigchunk.a: $(OBJDIR)/bigchunk.o
+	ar rv $@ $(OBJDIR)/bigchunk.o
 	ranlib $@
 
 clean:
 	rm -rf hip
+	rm -f dims-local.c
+	rm -f *.o *.a ForceTreeTest 2>/dev/null || true
 
 run: progs
 	$(LAUNCHER) ./hip/ForceTreeTest 0.5 0.1 10000 0.1 10 N 12 rcb


### PR DESCRIPTION
 Five static archives are built using the deprecated archive(member.o) syntax. Make implicitly expands these via its built-in .c.o and .o.a rules (which call cc), bypassing the project's hipcc recipe and mis-compiling the objects. Replace with explicit object-list prerequisites and an ar rv ... ; ranlib recipe.                                                                       
                                                                                                                                                                                                                                                                                                                                                                                               
dims-local.c is generated by cp -f dfft/dims.c dims-local.c but no rule declares dims-local.o depends on it. With make -j, the object compile can race ahead of the cp. Add an explicit prerequisite.                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                               
Also drop the redundant $(FORCE_OBJLIST_C) from libBHForceTree.a's prerequisites — those objects are already in $(FORCE_OBJECTS) (added via addprefix above), and listing them twice causes Make to try its implicit cc rule for the duplicates.                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                              
Extend clean to remove the generated dims-local.c and stray .o/.a/binary artifacts.