### PR TITLE
[snicit-hip] Add <cstring> header for memset

### DIFF
--- a/src/snicit-hip/src/SNICIT.hpp
+++ b/src/snicit-hip/src/SNICIT.hpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstring>
 #include <fstream>
 #include <string>
 #include "hip_error.hpp"


### PR DESCRIPTION
SNICIT.hpp calls memset on a host pointer (line 239) but doesn't include `<cstring>`. Without it, hipcc's transitive includes can resolve memset to a `__device__`-only intrinsic, breaking the host compile. Add the standard header to make the host declaration explicit.