### PR TITLE
[hpl-hip] Honor ROCM_PATH

### DIFF
--- a/src/hpl-hip/src/hpl-2.3/Make.intel64
+++ b/src/hpl-hip/src/hpl-2.3/Make.intel64
@@ -140,12 +140,13 @@ MPlib        = -lmpi #$(MPdir)/lib/release/libmpi.so
 # used. The variable LAdir is only used for defining LAinc and LAlib.
 #
 LAdir        ?= $(HOME)/lapack/build_lapack_32
+ROCM_PATH    ?= /opt/rocm
 LAinc        = -I$(LAdir)/include -I$(TOPdir)/src/cuda/
 LAlib 	     = -L$(TOPdir)/src/cuda/ -ldgemm \
 		-L$(LAdir)/lib/ -lcblas \
 		-L$(LAdir)/lib -lblas \
 		-lm -lstdc++ \
-		-L/opt/rocm/lib/ -lhipblas 
+		-L$(ROCM_PATH)/lib/ -lhipblas
 #
 # ----------------------------------------------------------------------
 # - F77 / C interface --------------------------------------------------

--- a/src/hpl-hip/src/hpl-2.3/src/cuda/Makefile
+++ b/src/hpl-hip/src/hpl-2.3/src/cuda/Makefile
@@ -105,12 +105,14 @@ DEFINES = -DMPI -g
 #DEFINES += -DACML
 #DEFINES += -DGOTO
 
+ROCM_PATH ?= /opt/rocm
+
 %.o: %.cpp
-	mpicc -O3 -c -fPIC $(DEFINES) $*.cpp -o $*.o -I/opt/rocm/include -D__HIP_PLATFORM_AMD__
+	mpicc -O3 -c -fPIC $(DEFINES) $*.cpp -o $*.o -I$(ROCM_PATH)/include -D__HIP_PLATFORM_AMD__
 
 libdgemm.so.1.0.1: $(OBJS)
 
-	mpicc -O3 -shared -Wl,-soname,libdgemm.so.1 -o libdgemm.so.1.0.1 $(OBJS) -L/opt/rocm/lib -lhipblas
+	mpicc -O3 -shared -Wl,-soname,libdgemm.so.1 -o libdgemm.so.1.0.1 $(OBJS) -L$(ROCM_PATH)/lib -lhipblas
 	ln -sf libdgemm.so.1.0.1 libdgemm.so.1.0
 	ln -sf libdgemm.so.1.0 libdgemm.so.1
 	ln -sf libdgemm.so.1 libdgemm.so


### PR DESCRIPTION
Replace hardcoded /opt/rocm with $(ROCM_PATH) ?= /opt/rocm so non-default ROCm installations (TheRock, Spack, custom prefixes) work without editing the Makefile.