### PR TITLE
[hpl-hip] Fix parallel-build race in src/hpl-2.3/Makefile

### DIFF
--- a/src/hpl-hip/src/hpl-2.3/Makefile
+++ b/src/hpl-hip/src/hpl-2.3/Makefile
@@ -108,11 +108,11 @@ startup          :
 	$(MAKE) -f Make.top refresh_src     arch=$(arch)
 	$(MAKE) -f Make.top refresh_tst     arch=$(arch)
 #
-refresh          :
+refresh          : startup
 	$(MAKE) -f Make.top refresh_src     arch=$(arch)
 	$(MAKE) -f Make.top refresh_tst     arch=$(arch)
 #
-build            :
+build            : startup refresh
 	$(MAKE) -f Make.top build_src       arch=$(arch)
 	$(MAKE) -f Make.top build_tst       arch=$(arch)
 #


### PR DESCRIPTION
HPL's top-level Makefile declares:                                                                                                                                                                                                                                                                                                                                                              
```                                                                                                                                                                                                                                                                                                                                                                                                  
      install : startup refresh build                                                                                                                                                                                                                                                                                                                                                           
      startup :                                                                                                                                                                                                                                                                                                                                                                                   
      refresh :                                                                                                                                                                                                                                                                                                                                                                                 
      build   :                                                                                                                                                                                                                                                                                                                                                                                 
 ```                                                                                                                                                                                                                                                                                                                                                                                                  with no inter-target dependencies between startup, refresh, and build.  Under serial `make`, this happens to work — make processes them in the listed order. Under `make -jN`, all three run concurrently, and the build fails:                                                                                                                                                                                                                                                                                                                                                                                    
 ```                                                                                                                                                                                                                                                                                                                                                                                                 
      make[3]: Entering directory '.../src/auxil/intel64'                                                                                                                                                                                                                                                                                                                                         
      Makefile:47: Make.inc: No such file or directory                                                                                                                                                                                                                                                                                                                                          
      make[3]: *** No rule to make target 'Make.inc'.  Stop.                                                                                                                                                                                                                                                                                                                                      
      make[1]: *** Waiting for unfinished jobs....                                                                                                                                                                                                                                                                                                                                                
  ```                                                                                                                                                                                                                                                                                                                                                                                                
The Make.inc symlinks under each src/<phase>/intel64/ are created by the `refresh` phase (`refresh_src` → `ln -fs ../../../Make.intel64 Make.inc`); the `build` phase descends into those directories and the inner Makefile does `include Make.inc` at its line 47. With no ordering enforced, build_src can race ahead of refresh_src and trip on the missing symlink.                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                  
Encode the implicit ordering by adding the missing dependencies:                                                                                                                                                                                                                                                                                                                                
  ```                                                                                                                                                                                                                                                                                                                                                                                              
      refresh : startup                                                                                                                                                                                                                                                                                                                                                                           
      build   : startup refresh                                                                                                                                                                                                                                                                                                                                                                 
  ```                                                                                                                                                                                                                                                                                                                                                                                                
No recipe changes; default serial behavior is preserved bit-for-bit (make already processed them in this order). For parallel builds, behavior changes from "races and breaks" to "correctly serializes the three phases at the top level" — heavy compile parallelism still happens inside the per-subdir Makefiles, which is where it actually matters.