### PR TITLE
[slu-hip] Serialize nicslu sub-make to fix parallel-build race

### DIFF
--- a/src/slu-hip/Makefile
+++ b/src/slu-hip/Makefile
@@ -84,8 +84,9 @@ $(SLU_PATH)/nicslu/Makefile: $(SLU_PATH)/nicslu.tar.bz2
 $(SLU_PATH)/nicslu/lib/nicslu.a: $(SLU_PATH)/nicslu/Makefile
 	$(MAKE) -C $(SLU_PATH)/nicslu/
 
-$(SLU_PATH)/nicslu/util/nicslu_util.a: $(SLU_PATH)/nicslu/Makefile
-	$(MAKE) -C $(SLU_PATH)/nicslu/
+# nicslu's top-level make builds both archives in one pass; depend on the
+# lib target to serialize and avoid a parallel-make race in `ar`.
+$(SLU_PATH)/nicslu/util/nicslu_util.a: $(SLU_PATH)/nicslu/lib/nicslu.a
 
 clean:
 	rm -rf $(program) $(obj) *.dat


### PR DESCRIPTION
The slu-hip Makefile had two independent rules — for nicslu/lib/nicslu.a and nicslu/util/nicslu_util.a — that each invoked `$(MAKE) -C nicslu/`. Under `make -j`, both fired concurrently, and since nicslu's top-level build descends into both lib/ and util/ in a single pass, two parallel sub-makes raced to compile the same .o files and to write the same lib/nicslu.a with `ar`. The result was a `Bus error (core dumped)` from ar, the archive being deleted by make's failure cleanup, and a cascade of link errors in the demo subdir.                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                  
The fix in this patch is to declaring nicslu_util.a as depending on nicslu.a (which the single sub-make produces alongside the util archive), so only one sub-make invocation ever runs.