### PR TITLE
[logic-rewrite-hip] Restore __syncwarp() in getCutTruthTableConsecutive

### DIFF
--- a/src/logic-rewrite-hip/truth.cuh
+++ b/src/logic-rewrite-hip/truth.cuh
@@ -259,7 +259,7 @@ __global__ void getCutTruthTableConsecutive(const int * pFanin0, const int * pFa
             vTruthMemAlloc[warpIdx] = (unsigned *) malloc(totalMemLen * sizeof(unsigned));
             assert(vTruthMemAlloc[warpIdx] != NULL); // if NULL, then not enough heap memory
         }
-        //__syncwarp();
+        __syncwarp();
         vTruthMem = vTruthMemAlloc[warpIdx] + startMemIdx;
         
 


### PR DESCRIPTION
In truth.cuh, lane 0 of each warp mallocs a per-warp scratch buffer and stores the pointer in shared vTruthMemAlloc[warpIdx]; the remaining lanes then read that pointer on the very next line. The __syncwarp() between the write and the read had been commented out, leaving the read to race against the write. Restoring the barrier fixes the issue.