### PR TITLE
Fix clean targets after binary renaming

### DIFF
--- a/src/b+tree-hip/Makefile
+++ b/src/b+tree-hip/Makefile
@@ -98,5 +98,6 @@ clean:
 		./kernel/*.o \
 		./util/timer/*.o \
 		./util/num/*.o \
+		main \
     output.txt
 

--- a/src/miniFE-hip/src/make_targets
+++ b/src/miniFE-hip/src/make_targets
@@ -41,7 +41,7 @@ run: main
 	./main -nx 128 -ny 128 -nz 128
 
 clean:
-	rm -f *.o *.a *.x *.linkinfo miniFE_info.hpp
+	rm -f *.o *.a *.x *.linkinfo miniFE_info.hpp main
 
 realclean: clean
 	rm -f gmon.out gprof.* *~ *.yaml *.TVD.* *.mtx* *.vec* minife_debug*

--- a/src/srad-hip/Makefile
+++ b/src/srad-hip/Makefile
@@ -53,7 +53,7 @@ $(program): $(obj) Makefile
 
 # delete all object files
 clean:
-	rm -f *.o srad *pgm
+	rm -f *.o srad *pgm main
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 1000 0.5 502 458


### PR DESCRIPTION
Binaries have been recently renamed to `main`, but not all clean targets were update to align with this change. This patch fixes the clean targets to adapt to the recent renaming.