### PR TITLE
[si-hip] Add run target to Makefile

### DIFF
--- a/src/si-hip/Makefile
+++ b/src/si-hip/Makefile
@@ -2,7 +2,7 @@
 # This wrapper drives the CMake build out-of-tree under release/ and
 # matches the all/clean interface the rest of HeCBench expects.
 
-.PHONY: all clean
+.PHONY: all clean run gen_dataset
 
 all:
 	mkdir -p release
@@ -11,3 +11,22 @@ all:
 
 clean:
 	rm -rf release
+
+# Encodes the manual run procedure documented in README.md:
+#   - generate the input dataset (asc + desc .bin files)
+#   - run the main set-intersection benchmark on each
+# The dataset is treated as a normal Make prerequisite so it is regenerated
+# only when generate_dataset is rebuilt or the .bin files are missing,
+# matching the README's two-phase compile/run flow without paying the
+# regeneration cost on every rerun.
+DATASET = release/out_asc_uniform_1000_1000_100.bin \
+          release/out_desc_uniform_1000_1000_100.bin
+
+$(DATASET): release/generate_dataset
+	cd release && ./generate_dataset --iterations 100 --universe 1000 -k 1000
+
+gen_dataset: $(DATASET)
+
+run: all gen_dataset
+	cd release && ./main --input out_asc_uniform_1000_1000_100.bin
+	cd release && ./main --input out_desc_uniform_1000_1000_100.bin


### PR DESCRIPTION
Convert the manual run procedure documented in README.md into an actual Makefile target. The dataset generator is split into a separate `gen_dataset` target whose outputs are normal Make prerequisites of `run`, so the dataset is only regenerated when generate_dataset is rebuilt or the .bin files are missing — saving the regeneration cost on rerun without changing observable behavior.