### PR TITLE
[mf-sgd-hip] Copy binary to benchmark root dir for run.sh to find it

### DIFF
--- a/src/mf-sgd-hip/Makefile
+++ b/src/mf-sgd-hip/Makefile
@@ -1,10 +1,16 @@
 .PHONY: all clean run
 
+# `data/netflix/run.sh` (shipped with the downloaded Netflix dataset)
+# invokes the binary as `../../main` — i.e. it expects `main` at the
+# benchmark root, not under `src/`. Stage a copy at the root so `make
+# run` works without modifying the dataset-side script.
 all:
 	$(MAKE) -C src
+	cp -f src/main main
 
 clean:
 	$(MAKE) -C src clean
+	rm -f main
 
 # Netflix dataset must be downloaded first (see data/README); run.sh
 # invokes the trained binary with the dataset paths.


### PR DESCRIPTION
README file instructs users to download Netflix dataset and use the run.sh script included with it. The mentioned run.sh script included with Netflix dataset invokes the binary as `../../main` — i.e. it expects `main` at the benchmark root, not under `src/`. Copy the binary to the root dir so `make run` works without modifying the dataset-side script.