### PR TITLE
[si-hip] fix make run failing with 'No rule to make target' from cold

### DIFF
--- a/src/si-hip/Makefile
+++ b/src/si-hip/Makefile
@@ -2,7 +2,7 @@
 # This wrapper drives the CMake build out-of-tree under release/ and
 # matches the all/clean interface the rest of HeCBench expects.
 
-.PHONY: all clean run gen_dataset
+.PHONY: all clean run
 
 all:
 	mkdir -p release
@@ -15,18 +15,16 @@ clean:
 # Encodes the manual run procedure documented in README.md:
 #   - generate the input dataset (asc + desc .bin files)
 #   - run the main set-intersection benchmark on each
-# The dataset is treated as a normal Make prerequisite so it is regenerated
-# only when generate_dataset is rebuilt or the .bin files are missing,
-# matching the README's two-phase compile/run flow without paying the
-# regeneration cost on every rerun.
+# The dataset depends order-only on `all` (built by CMake as a side effect)
+# so Make doesn't try to find a rule for `release/generate_dataset` at parse
+# time. The .bin files cache between runs; `make clean` forces regeneration
+# along with the rebuild.
 DATASET = release/out_asc_uniform_1000_1000_100.bin \
           release/out_desc_uniform_1000_1000_100.bin
 
-$(DATASET): release/generate_dataset
+$(DATASET): | all
 	cd release && ./generate_dataset --iterations 100 --universe 1000 -k 1000
 
-gen_dataset: $(DATASET)
-
-run: all gen_dataset
+run: $(DATASET)
 	cd release && ./main --input out_asc_uniform_1000_1000_100.bin
 	cd release && ./main --input out_desc_uniform_1000_1000_100.bin


### PR DESCRIPTION
The `run` target added previously fails on a clean tree:                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                  
      $ make clean && make run                                                                                                                                                                                                                                                                                                                                                                    
      make: *** No rule to make target 'release/generate_dataset',                                                                                                                                                                                                                                                                                                                                
              needed by 'release/out_asc_uniform_1000_1000_100.bin'.  Stop.                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                  
`release/generate_dataset` was declared as a regular prerequisite of the dataset .bin files. Make builds its dependency tree at parse time: it sees the prereq, looks for a rule to build it, finds none (it's a CMake side-effect of `all`), and aborts before `all` has a chance to run. The target only worked if `release/` was already populated by a prior build — which is why CI / first-time users hit it but local developers didn't. Fix by switching to an *order-only* dependency on `all`:                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                  
      $(DATASET): | all                                                                                                                                                                                                                                                                                                                                                                         
              cd release && ./generate_dataset --iterations 100 --universe 1000 -k 1000                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                
      run: $(DATASET)                                                                                                                                                                                                                                                                                                                                                                             
              cd release && ./main --input out_asc_uniform_1000_1000_100.bin                                                                                                                                                                                                                                                                                                                      
              cd release && ./main --input out_desc_uniform_1000_1000_100.bin                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                  
Order-only (`| all`) tells Make "make sure `all` runs first, but don't track its mtime as a regen trigger." That sidesteps the parse-time rule lookup for `release/generate_dataset` (Make never tries to find one) while still guaranteeing the binary exists by the time the dataset recipe runs. Also drops the `gen_dataset` PHONY indirection — `run` can depend on `$(DATASET)` directly.