### PR TITLE
[mlp-hip] fix hipblasLt handle silently uninitialized under -DNDEBUG

### DIFF
--- a/src/mlp-hip/main.cu
+++ b/src/mlp-hip/main.cu
@@ -167,7 +167,8 @@ int main(int argc, char* argv[])
   GPU_CHECK(hipMalloc(&lt_workspace, lt_workspace_size));
 
   // hipBLASLt handle (global variable)
-  assert(hipblasLtCreate(&handle) == HIPBLAS_STATUS_SUCCESS);
+  [[maybe_unused]] hipblasStatus_t lt_create_status = hipblasLtCreate(&handle);
+  assert(lt_create_status == HIPBLAS_STATUS_SUCCESS);
 
   long time = 0;
 
@@ -256,6 +257,7 @@ int main(int argc, char* argv[])
   GPU_CHECK(hipFree(lt_workspace));
   free_mlp_space(w_ptr, num_layers);
   free_mlp_space(b_ptr, num_layers);
-  assert(hipblasLtDestroy(handle) == HIPBLAS_STATUS_SUCCESS);
+  [[maybe_unused]] hipblasStatus_t lt_destroy_status = hipblasLtDestroy(handle);
+  assert(lt_destroy_status == HIPBLAS_STATUS_SUCCESS);
   return error;
 }


### PR DESCRIPTION
`src/mlp-hip/main.cu` wraps required hipBLASLt calls inside `assert()`:

```cpp
assert(hipblasLtCreate(&handle) == HIPBLAS_STATUS_SUCCESS);
assert(hipblasLtDestroy(handle) == HIPBLAS_STATUS_SUCCESS);
```

When the benchmark is compiled with -DNDEBUG (standard for release builds), assert(expr) expands to a no-op and expr is not evaluated. The `hipblasLtCreate` call is elided entirely, leaving handle uninitialized.
The first hipBLASLt API call then fails with invalid pointer in rocblaslt_matmul_algo_get_heuristic, and the benchmark prints MLP execution failed.

This is the canonical "assert with side effects" C/C++ bug — it works in debug builds and silently breaks in release.