### PR TITLE
[bn-hip] Fix out-of-bounds read in D_findindex for empty parent set

### DIFF
--- a/src/bn-hip/kernels.cu
+++ b/src/bn-hip/kernels.cu
@@ -269,6 +269,8 @@ __device__ void D_findComb(int* comb, int l, int n)
 }
 
 __device__ int D_findindex(int *arr, int size){  //reminder: arr[0] has to be 0 && size == array size-1 && index start from 0
+  if (size == 0) return 0;  // empty parent set maps to slot 0 (matches D_findComb(l=0))
+
   int i,j,index=0;
 
   for(i=1;i<size;i++){


### PR DESCRIPTION
`D_findindex(arr, size)` in `src/bn-hip/kernels.cu` is called from `computeKernel` with `size = parN`, the size of a node's parent set. When `parN == 0` (a node with no parents — always the case for `D_findComb(l=0)` on thread 0 of block 0), the function falls through to its inner loop logic and ends up reading `arr[-1]` from device-local memory before returning.

This is undefined behavior. The observed symptoms vary by target:
- **gfx90a (MI200):** scratch memory at that offset happens to be zero, so `D_findindex` accidentally returns the correct slot index (0). The benchmark passes by luck.
- **amdgcnspirv:** scratch memory contains uninitialized garbage. The bogus value is used as an array index and triggers a Memory Fault in `computeKernel` on the first launch.

The bug is latent on every target; only the symptom is target-dependent.