### PR TITLE
[scripts] Fix aobench regex

### DIFF
--- a/src/scripts/benchmarks/subset.json
+++ b/src/scripts/benchmarks/subset.json
@@ -53,7 +53,7 @@
         ]
     ],
     "aobench": [
-        "(?:Average render time: )([0-9.+-e]+)(?: sec)",
+        "(?:Average kernel time: )([0-9.+-e]+)(?: usec)",
         [
             "1000"
         ]


### PR DESCRIPTION
Follow-up to a6eca659e2071a54bab6a402a9f21edf1e675b72