### PR TITLE
Fix adv benchmarks.yaml: test args do not match kernel compile-time constants

### DIFF
--- a/benchmarks.yaml
+++ b/benchmarks.yaml
@@ -63,7 +63,7 @@ adv:
   models: [cuda, hip, omp, sycl]
   test:
     regex: '(?:elapsed time=)([0-9.+-e]+)(?: )'
-    args: ["16", "16", "16"]
+    args: ["7", "15", "16"]
     timeout: 300
 
 aes:


### PR DESCRIPTION
## Summary

Fixes incorrect test arguments for the `adv` benchmark that cause correctness failures on all GPU platforms (CUDA, HIP, SYCL, OpenMP).

Fixes #246

## Root Cause

The `advCubatureHex3D` kernel in `src/adv-{cuda,hip}/adv.h` hardcodes compile-time constants:
- `p_Nq = 8` → requires N = 7 (Nq = N+1 = 8)
- `p_cubNq = 16` → requires cubN = 15 (cubNq = 16)

The previous args `[\, \, \]` gave Nq=17 ≠ p_Nq=8, causing shared memory out-of-bounds reads and wrong results on all platforms.

## Change

```diff
-    args: [\, \, \]
+    args: [\, \, \]
```

## Verification (AMD MI300X gfx942, ROCm 7.2)

| Command | Result |
|---------|--------|
| `adv 16 16 16 1` | ❌ FAIL — index 8192: 0.691294 ≠ 0.583546 |
| `adv 7 15 1 1` | ✅ PASS |
| `adv 7 15 4 1` | ✅ PASS |
| `adv 7 15 16 1` | ✅ PASS |
| `adv 7 15 64 1` | ✅ PASS |

Failure occurs on all platforms (CUDA/HIP/SYCL/OpenMP) — not AMD-specific.
