### PR TITLE
[bn-{cuda,hip}] Fix off-by-one in computeKernel D_findComb call causing GPU memory fault

### DIFF
--- a/src/bn-cuda/kernels.h
+++ b/src/bn-cuda/kernels.h
@@ -114,7 +114,7 @@ __global__ void computeKernel(const int taskperthr,
 
   for(i=0;i<taskperthr&&((id*taskperthr+i)<total);i++){
 
-    D_findComb(parent,id*taskperthr+i,posN);
+    D_findComb(parent,id*taskperthr+i,posN-1);
 
     for(parN=0;parN<4;parN++){
       if(parent[parN]<0) break;


### PR DESCRIPTION
- Fix out-of-bounds access in `computeKernel` in `bn-cuda/kernels.h` that caused "Memory access fault by GPU" on every run
- The kernel's `posN` starts at `1` (1-indexed pre array), so it equals `num_predecessors + 1`. Passing `posN` to `D_findComb` as the element count generated combination values up to `posN`, which accessed `pre[posN]` — one past the valid range `pre[1..posN-1]`
- The garbage value read from the stack produced out-of-bounds indices into `D_localscore`, triggering the fault (reliably on nodes with many predecessors, e.g. node=9 with 44 predecessors)
