### PR TITLE
[resnet-kernels-hip] Bake data generation into Makefile

### DIFF
--- a/src/resnet-kernels-hip/Makefile
+++ b/src/resnet-kernels-hip/Makefile
@@ -56,7 +56,10 @@ $(program): $(obj)
 clean:
 	rm -rf $(program) $(obj)
 
-run: $(program)
+data/input_14_1_128.bin:
+	cd ../resnet-kernels-cuda && mkdir -p data && python3 data_generator.py
+
+run: $(program) data/input_14_1_128.bin
 	$(LAUNCHER) ./$(program) 0 100
 	$(LAUNCHER) ./$(program) 1 100
 	$(LAUNCHER) ./$(program) 2 100


### PR DESCRIPTION
This patch creates a new Makefile target to generate the input data, and adds it as a dependency to the run target.