### PR TITLE
[gmm-hip] Fix validation error

### DIFF
--- a/src/gmm-hip/cluster.cu
+++ b/src/gmm-hip/cluster.cu
@@ -448,7 +448,7 @@ clusters_t* cluster(int original_num_clusters, int desired_num_clusters,
     // Calculates a cluster membership probability
     // for each event and each cluster.
     DEBUG("Invoking E-step kernels.");
-    hipLaunchKernelGGL(estep1, dim3(num_clusters), dim3(NUM_BLOCKS), NUM_THREADS_ESTEP, 0, d_fcs_data_by_dimension,d_clusters,num_dimensions,num_events);
+    hipLaunchKernelGGL(estep1, dim3(num_clusters, NUM_BLOCKS), dim3(NUM_THREADS_ESTEP), 0, 0, d_fcs_data_by_dimension,d_clusters,num_dimensions,num_events);
     hipLaunchKernelGGL(estep2, dim3(NUM_BLOCKS), dim3(NUM_THREADS_ESTEP), 0, 0, d_fcs_data_by_dimension,d_clusters,num_dimensions,num_clusters,num_events,d_likelihoods);
     regroup_iterations++;
 
@@ -552,7 +552,7 @@ clusters_t* cluster(int original_num_clusters, int desired_num_clusters,
 
       DEBUG("Invoking regroup (E-step) kernel with %d blocks.\n",NUM_BLOCKS);
       // Compute new cluster membership probabilities for all the events
-      hipLaunchKernelGGL(estep1, dim3(num_clusters), dim3(NUM_BLOCKS), NUM_THREADS_ESTEP, 0, d_fcs_data_by_dimension,d_clusters,num_dimensions,num_events);
+      hipLaunchKernelGGL(estep1, dim3(num_clusters, NUM_BLOCKS), dim3(NUM_THREADS_ESTEP), 0, 0, d_fcs_data_by_dimension,d_clusters,num_dimensions,num_events);
       hipLaunchKernelGGL(estep2, dim3(NUM_BLOCKS), dim3(NUM_THREADS_ESTEP), 0, 0, d_fcs_data_by_dimension,d_clusters,num_dimensions,num_clusters,num_events,d_likelihoods);
       regroup_iterations++;
 

--- a/src/gmm-hip/gaussian_kernel.cu
+++ b/src/gmm-hip/gaussian_kernel.cu
@@ -144,9 +144,9 @@ __device__ void compute_pi(clusters_t* clusters, int num_clusters) {
 
   for(int c = threadIdx.x; c < num_clusters; c += blockDim.x) {
     if(clusters->N[c] < 0.5f) {
-      clusters->pi[threadIdx.x] = 1e-10;
+      clusters->pi[c] = 1e-10;
     } else {
-      clusters->pi[threadIdx.x] = clusters->N[c] / sum;
+      clusters->pi[c] = clusters->N[c] / sum;
     }
   }
 
@@ -278,9 +278,9 @@ constants_kernel(clusters_t* clusters, int num_clusters, int num_dimensions) {
 
     for(int i = tid; i < num_clusters; i += num_threads) {
       if(clusters->N[i] < 0.5f) {
-        clusters->pi[tid] = 1e-10;
+        clusters->pi[i] = 1e-10;
       } else {
-        clusters->pi[tid] = clusters->N[i] / sum;
+        clusters->pi[i] = clusters->N[i] / sum;
       }
     }
   }

--- a/src/gmm-hip/readData.cu
+++ b/src/gmm-hip/readData.cu
@@ -65,11 +65,11 @@ float* readCSV(char* f, int* ndims, int* nevents) {
         line1 = lines[0];
         string line2 (line1.begin(), line1.end());
 
-        temp = strtok((char*)line1.c_str(), ",");
+        temp = strtok((char*)line1.c_str(), ", \t");
 
         while(temp != NULL) {
             num_dims++;
-            temp = strtok(NULL, ",");
+            temp = strtok(NULL, ", \t");
         }
 
         lines.erase(lines.begin()); // Remove first line, assumed to be header
@@ -88,7 +88,7 @@ float* readCSV(char* f, int* ndims, int* nevents) {
         }
 
         for (int i = 0; i < num_events; i++) {
-            temp = strtok((char*)lines[i].c_str(), ",");
+            temp = strtok((char*)lines[i].c_str(), ", \t");
 
             for (int j = 0; j < num_dims; j++) {
                 if(temp == NULL) {
@@ -96,7 +96,7 @@ float* readCSV(char* f, int* ndims, int* nevents) {
                     return NULL;
                 }
                 data[i * num_dims + j] = atof(temp);
-                temp = strtok(NULL, ",");
+                temp = strtok(NULL, ", \t");
             }
         }
 


### PR DESCRIPTION
gmm-hip fails validation in gfx90a. This PR addresses multiple issues that add up to the validation error:
  - compute_pi(): replace `clusters->pi[threadIdx.x]` with `clusters->pi[c]` (loop variable mismatch)
  - constants_kernel(): replace `clusters->pi[tid] → clusters->pi[i] (same bug, inlined copy)
  - estep1 launch: Use correct launch args for `hipLaunchKernelGGL`. Specifically, replace `(estep1, dim3(num_clusters), dim3(NUM_BLOCKS), NUM_THREADS_ESTEP, 0, ...)` with `(estep1, dim3(num_clusters, NUM_BLOCKS), 
  dim3(NUM_THREADS_ESTEP), 0, 0, ...)`. Note that the 2D CUDA grid `dim3(num_clusters, NUM_BLOCKS)` was incorrectly split into grid + block args during hipification, making estep1 run with 24 threads instead of 256. The fix is to align with CUDA version.
  - CSV parser: replace strtok delimiter "," with ", \t" on all 4 call sites because input data is space-delimited, not comma-delimited.