### PR TITLE
[gru-hip] Fix overallocation that results into validation error

### DIFF
--- a/src/gru-hip/main.cu
+++ b/src/gru-hip/main.cu
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
   const int bias_size = 3 * hsz;
   const size_t bias_size_bytes = bias_size * sizeof(half);
 
-  const int store_size = 5 * vsz * hsz;
+  const int store_size = 5 * vsz;
   const size_t store_size_bytes = store_size * sizeof(half);
 
   const int state_size = vsz;


### PR DESCRIPTION
The actual elements are `5 * vsz`, the extra `* hsz` was an overallocation. The extra elements were never written, so they had garbage resulting into validation errors on gfx90a:

```
./main 102400 1024 100
Average execution time of gru_cell_forward: 14.186831 (us)
FAIL
```