### PR TITLE
[minimap2-hip] Rename HIP_PATH Makefile variable to avoid collision with HIP toolchain

### DIFF
--- a/src/minimap2-hip/Makefile
+++ b/src/minimap2-hip/Makefile
@@ -3,7 +3,7 @@ HIPCC = hipcc
 
 # path #
 SRC_PATH = src
-HIP_PATH = device
+HIP_SRC_PATH = device
 BUILD_PATH = build
 BUILD_HIP_PATH = build/hip
 BIN_PATH = $(BUILD_PATH)/bin
@@ -19,11 +19,11 @@ HIP_EXT = cu
 # Find all source files in the source directory, sorted by
 # most recently modified
 SOURCES = $(shell find $(SRC_PATH) -name '*.$(SRC_EXT)' | sort -k 1nr | cut -f2-)
-HIP_SOURCES = $(shell find $(HIP_PATH) -name '*.$(HIP_EXT)' | sort -k 1nr | cut -f2-)
+HIP_SOURCES = $(shell find $(HIP_SRC_PATH) -name '*.$(HIP_EXT)' | sort -k 1nr | cut -f2-)
 # Set the object file names, with the source directory stripped
 # from the path, and the build path prepended in its place
 OBJECTS = $(SOURCES:$(SRC_PATH)/%.$(SRC_EXT)=$(BUILD_PATH)/%.o)
-HIP_OBJECTS = $(HIP_SOURCES:$(HIP_PATH)/%.$(HIP_EXT)=$(BUILD_HIP_PATH)/%.o)
+HIP_OBJECTS = $(HIP_SOURCES:$(HIP_SRC_PATH)/%.$(HIP_EXT)=$(BUILD_HIP_PATH)/%.o)
 # Set the dependency files that will be used to add header dependencies
 DEPS = $(OBJECTS:.o=.d)
 
@@ -80,7 +80,7 @@ $(BUILD_PATH)/%.o: $(SRC_PATH)/%.$(SRC_EXT)
 	@echo "Compiling: $< -> $@"
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -MP -MMD -c $< -o $@
 
-$(BUILD_HIP_PATH)/%.o: $(HIP_PATH)/%.$(HIP_EXT)
+$(BUILD_HIP_PATH)/%.o: $(HIP_SRC_PATH)/%.$(HIP_EXT)
 	@echo "Compiling: $< -> $@"
 	$(HIPCC) $(HIPCCFLAGS) $(INCLUDES) -c $< -o $@
 


### PR DESCRIPTION
The minimap2-hip Makefile uses HIP_PATH as an internal variable pointing to the device/ source directory. HIP_PATH is a standard environment variable consumed by hipcc and hipconfig to locate the HIP runtime headers and libraries. When Make's recursive invocation leaks this variable into the environment, hipcc looks for hip/hip_runtime.h under device/ instead of the ROCm installation, causing the build to fail with `fatal error: 'hip/hip_runtime.h' file not found`. Rename the variable to HIP_SRC_PATH to avoid the collision. No functional change — the variable is purely internal to the Makefile.