### PR TITLE
Check hipblas status and only validate if successful

### DIFF
--- a/src/blas-gemm-hip/main.cu
+++ b/src/blas-gemm-hip/main.cu
@@ -86,20 +86,26 @@ void run_gemm_example(int m, int k, int n, int repeat) {
   std::cout << "Checking BLAS GEMM.. ";
   run_simple_gemm(da, db, dr, m, k, n, alpha, beta);
 
+  hipblasStatus_t status;
   if constexpr (std::is_same_v<fp, __half>)
-    hipblasHgemm(h, HIPBLAS_OP_N, HIPBLAS_OP_N, n, m, k,
+    status = hipblasHgemm(h, HIPBLAS_OP_N, HIPBLAS_OP_N, n, m, k,
                 &alpha, db, n, da, k, &beta, dc, n);
   else if constexpr (std::is_same_v<fp, float>)
-    hipblasSgemm(h, HIPBLAS_OP_N, HIPBLAS_OP_N, n, m, k,
+    status = hipblasSgemm(h, HIPBLAS_OP_N, HIPBLAS_OP_N, n, m, k,
                 &alpha, db, n, da, k, &beta, dc, n);
   else if constexpr (std::is_same_v<fp, double>)
-    hipblasDgemm(h, HIPBLAS_OP_N, HIPBLAS_OP_N, n, m, k,
+    status = hipblasDgemm(h, HIPBLAS_OP_N, HIPBLAS_OP_N, n, m, k,
                 &alpha, db, n, da, k, &beta, dc, n);
 
-  hipMemcpy(c, dc, C_size, hipMemcpyDeviceToHost);
-  hipMemcpy(r, dr, C_size, hipMemcpyDeviceToHost);
-  int error = memcmp(c, r, C_size);
-  std::cout << (error ? "FAIL" : "PASS") << std::endl;
+  if (status != HIPBLAS_STATUS_SUCCESS) {
+    std::cout << "Check skipped because hipblas returned non-success status "
+              << status << std::endl;
+  } else {
+    hipMemcpy(c, dc, C_size, hipMemcpyDeviceToHost);
+    hipMemcpy(r, dr, C_size, hipMemcpyDeviceToHost);
+    int error = memcmp(c, r, C_size);
+    std::cout << (error ? "FAIL" : "PASS") << std::endl;
+  }
 
   hipDeviceSynchronize();
   auto start = std::chrono::steady_clock::now();

--- a/src/blas-gemmBatched-hip/main.cu
+++ b/src/blas-gemmBatched-hip/main.cu
@@ -162,20 +162,25 @@ void gemmBatched(
       auto elapsed = time * 1e-3;
 
       if(stat != HIPBLAS_STATUS_SUCCESS){
-	cerr << "hipblasSgemmBatched failed" << endl;
+        cerr << "Size " << size
+             << " skipped because hipblas returned non-success status " << stat
+             << endl;
         break;
       }
 
       if (rep != 0) sum += elapsed;
       
       if(verbose)
-	cout << "size " << size << ": " << elapsed << " us; " 
-	     << elapsed / num << " us per operation" << endl;
+        cout << "size " << size << ": " << elapsed << " us; " << elapsed / num
+             << " us per operation" << endl;
     }
-    cout << "size " << size << " average execution time: " << sum/reps << " us; "
-	 << sum / reps / num << " us per operation; "
-         << "floating-point operations per second: ";
-    performance(m, n, k, 1e3 * (sum / reps / num));
+
+    if (stat == HIPBLAS_STATUS_SUCCESS) {
+      cout << "size " << size << " average execution time: " << sum / reps
+           << " us; " << sum / reps / num << " us per operation; "
+           << "floating-point operations per second: ";
+      performance(m, n, k, 1e3 * (sum / reps / num));
+    }
 
     // verify double precision operations 
     if constexpr (std::is_same_v<T, double>) {

--- a/src/blas-gemmStridedBatched-hip/main.cu
+++ b/src/blas-gemmStridedBatched-hip/main.cu
@@ -128,7 +128,9 @@ void gemmBatched(
       auto elapsed = time * 1e-3;
 
       if(stat != HIPBLAS_STATUS_SUCCESS){
-        cerr << "hipblasXgemmStridedBatched failed" << endl;
+        cerr << "Size " << size
+             << " skipped because hipblas returned non-success status "
+             << status << endl;
         break;
       }
 
@@ -138,10 +140,13 @@ void gemmBatched(
 	cout << "size " << size << ": " << elapsed << " us; " 
 	     << elapsed / num << " us per operation" << endl;
     }
-    cout << "size " << size << " average execution time: " << sum/reps << " us; "
-	 << sum / reps / num << " us per operation; "
-         << "floating-point operations per second: ";
-    performance(m, n, k, 1e3 * (sum / reps / num));
+
+    if (stat == HIPBLAS_STATUS_SUCCESS) {
+      cout << "size " << size << " average execution time: " << sum / reps
+           << " us; " << sum / reps / num << " us per operation; "
+           << "floating-point operations per second: ";
+      performance(m, n, k, 1e3 * (sum / reps / num));
+    }
 
     // verify double precision operations 
     if constexpr (std::is_same_v<T, double>) {


### PR DESCRIPTION
Prior to this patch, these benchmarks were trying validation even if the hipblas functions returned error, resulting in misleading validation errors that were actually hipblas errors.