### PR TITLE
[gd] Widen obj_val validation tolerance to 5e-3 for unsafe-fp-atomics compatibility

### DIFF
--- a/src/gd-cuda/reference.h
+++ b/src/gd-cuda/reference.h
@@ -120,7 +120,7 @@ void reference (Classification_Data_CRS &A,
     update_ref(h_x, h_grad, m, n, lambda, alpha);
   }
 
-  bool ok = (fabsf(obj_val - h_obj_val) < 1e-3f) &&
+  bool ok = (fabsf(obj_val - h_obj_val) < 5e-3f) &&
             (fabsf(train_error - h_train_error) < 1e-3f);
   printf("%s\n", ok ? "PASS" : "FAIL");
 


### PR DESCRIPTION
This benchmark uses `-munsafe-fp-atomics` flag, which affects the precision of the results. I ran into flaky validation failures in 5 out of 50 runs on gfx90a. Specifically, I found `obj_val` being slightly above the tolerance, while never observed any problem with `train_error`. The reference CPU value for `obj_val` is `0.335840` and the current tolerance is `1e-3f`. The worst case I have found --understood as the most difference between gpu value and reference value-- was 0.3374. Considering the use of unsafe atomics, and the data above, widing the tolerance for `obj_val` sounds reasonable to me.