### PR TITLE
[unfold-hip] Initialize buffer after allocation

### DIFF
--- a/src/unfold-hip/main.cu
+++ b/src/unfold-hip/main.cu
@@ -110,6 +110,7 @@ int main(int argc, char* argv[])
   hipMemcpy(d_idx_dim, &h_idx_dim, sizeof(int64_t), hipMemcpyHostToDevice); 
 
   hipMalloc((void**)&d_grad_out, output_size_bytes);
+  hipMemset(d_grad_out, 0, output_size_bytes);
 
   auto start = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
Without initialization, the buffer contains garbage, which ends up causing validation errors because the kernel accumulates into it with `+=`:
```
./main 10000000 1000
Average execution time of unfold backward kernel: 104.177765 (us)
FAIL
```