### PR TITLE
[spsm] Fix matrix initialization for sparse triangular solve

### DIFF
--- a/src/spsm-cuda/main.cu
+++ b/src/spsm-cuda/main.cu
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
   // Host problem definition
   const int A_num_rows = m;  // a square matrix
   const int A_num_cols = m;
-  const int A_nnz      = a_nnz;
+  int       A_nnz      = a_nnz;
   const int lda        = A_num_cols;
   const int A_size     = lda * A_num_rows;
 
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
   int *hA_offsets = (int*) malloc (A_rowidx_size_bytes);
 
   printf("Initializing host matrices..\n");
-  init_matrix(hA, A_num_rows, A_num_cols, A_nnz);
+  A_nnz = init_lower_triangular_matrix(hA, A_num_rows, A_nnz);
   init_csr(hA_offsets, hA_values, hA_columns, hA,
            A_num_rows, A_num_cols, A_nnz);
 

--- a/src/spsm-cuda/utils.h
+++ b/src/spsm-cuda/utils.h
@@ -29,6 +29,55 @@ void init_matrix(float *matrix, int num_rows, int num_cols, int nnz)
   free(d);
 }
 
+// Generate a lower-triangular sparse matrix with guaranteed non-zero diagonal.
+// nnz must be >= num_rows (one entry per diagonal element minimum).
+// Distributes the remaining nnz - num_rows entries in the strict lower triangle.
+// Returns the actual nnz (clamped if requested nnz exceeds lower-triangular capacity).
+int init_lower_triangular_matrix(float *matrix, int num_rows, int nnz)
+{
+  int num_cols = num_rows;
+  int n = num_rows * num_cols;
+
+  if (nnz < num_rows) nnz = num_rows;
+
+  // total lower-triangular positions: num_rows*(num_rows+1)/2
+  long long lower_total = (long long)num_rows * (num_rows + 1) / 2;
+  if (nnz > lower_total) nnz = (int)lower_total;
+
+  // start with all zeros
+  for (int i = 0; i < n; i++) matrix[i] = 0.f;
+
+  // number of strictly-lower-triangle positions (excluding diagonal)
+  long long strict_lower = (long long)num_rows * (num_rows - 1) / 2;
+  int extra = nnz - num_rows;  // non-zeros to place off-diagonal
+
+  // Selection-sample 'extra' positions from strict lower triangle
+  srand(123);
+  for (long long k = 0; k < strict_lower && extra > 0; k++) {
+    if ((rand() % (strict_lower - k)) < extra) {
+      // map linear index k to (row, col) in strict lower triangle
+      // row r has columns 0..r-1, starting at offset r*(r-1)/2
+      int r = (int)((1.0 + sqrt(1.0 + 8.0 * k)) / 2.0);
+      if ((long long)r * (r - 1) / 2 > k) r--;
+      int c = (int)(k - (long long)r * (r - 1) / 2);
+      matrix[r * num_cols + c] = 1.f;  // placeholder, will set value below
+      extra--;
+    }
+  }
+
+  // fill all marked off-diagonal entries and diagonal with random values
+  srand48(123);
+  for (int i = 0; i < num_rows; i++) {
+    for (int j = 0; j < i; j++) {
+      if (matrix[i * num_cols + j] != 0.f)
+        matrix[i * num_cols + j] = (float)(drand48() + 1);
+    }
+    matrix[i * num_cols + i] = (float)(drand48() + 1);  // diagonal always non-zero
+  }
+
+  return nnz;
+}
+
 void init_csr(int *row_indices, float *values,
               int *col_indices, float *matrix,
               int num_rows, int num_cols, int nnz)

--- a/src/spsm-hip/main.cu
+++ b/src/spsm-hip/main.cu
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
   // Host problem definition
   const int A_num_rows = m;  // a square matrix
   const int A_num_cols = m;
-  const int A_nnz      = a_nnz;
+  int       A_nnz      = a_nnz;
   const int lda        = A_num_cols;
   const int A_size     = lda * A_num_rows;
 
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
   int *hA_offsets = (int*) malloc (A_rowidx_size_bytes);
 
   printf("Initializing host matrices..\n");
-  init_matrix(hA, A_num_rows, A_num_cols, A_nnz);
+  A_nnz = init_lower_triangular_matrix(hA, A_num_rows, A_nnz);
   init_csr(hA_offsets, hA_values, hA_columns, hA,
            A_num_rows, A_num_cols, A_nnz);
 


### PR DESCRIPTION
The benchmark uses `init_matrix()` to initialize a general sparse matrix, but `{cu,hip}sparseSpSM_solve` expect a triangular matrix. `init_matrix()` doesn't satisfy the required preconditions, which may lead to incorrect results, as shown below.

```
./main 20082 128 150616 100 1
Initializing host matrices..
Done
Average execution time of SpSM solve: 223.996048 (us)
Checking results..
@9216 1.324598 != 0.000000
spsm_csr_example test FAILED: wrong result
```

There are two main issues:
1. Upper-triangular entries in the CSR. `init_matrix()` distributes non-zeros across the entire matrix, but then the benchmark uses `HIPSPARSE_FILL_MODE_LOWER`, which assumes that it will only contain lower-triangular entries. Note that the host-side reference `spsm()` in utils.h correctly uses only the lower triangle thanks to `if (k < i+1)`. 
2. Zero diagonal entries. The benchmark uses `HIPSPARSE_DIAG_TYPE_NON_UNIT`, which makes the solver use the actual diagonal values. However, at low density (make run default params: M=20082, nnz=150616 gives ~0.04% density), most of the diagonal entries are zero. 

This PR adds `init_lower_triangular_matrix()` to utils.h, which directly generates a lower-triangular sparse matrix with guaranteed non-zero diagonal entries. Both the CUDA and HIP variants are updated to use it.