### PR TITLE
[bitcracker] Remove CUDA header requirement for HIP path

### DIFF
--- a/src/bitcracker-cuda/bitcracker.h
+++ b/src/bitcracker-cuda/bitcracker.h
@@ -19,6 +19,9 @@
  * along with BitCracker. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BITCRACKER_H
+#define BITCRACKER_H
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <stdio.h>
@@ -112,3 +115,5 @@ int parse_data(char *input_hash, unsigned char ** salt, unsigned char ** nonce,	
 char * strtokm(char *s1, const char *delims);
 void attack(char *dname, uint32_t * d_w_words_uint32, unsigned char * encryptedVMK, unsigned char * nonce, unsigned char * encryptedMAC, int gridBlocks);
 void * Calloc(size_t len, size_t size);
+
+#endif

--- a/src/bitcracker-hip/CMakeLists.txt
+++ b/src/bitcracker-hip/CMakeLists.txt
@@ -9,3 +9,7 @@ add_hecbench_benchmark(
     COMPILE_OPTIONS -ffast-math
     CATEGORIES algorithms
 )
+
+set_source_files_properties(${INC_DIR}/utils.cpp PROPERTIES
+    COMPILE_OPTIONS "-include;${CMAKE_CURRENT_LIST_DIR}/bitcracker.h"
+)

--- a/src/bitcracker-hip/Makefile
+++ b/src/bitcracker-hip/Makefile
@@ -49,7 +49,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 utils.o: ../bitcracker-cuda/utils.cpp Makefile
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -include bitcracker.h -c $< -o $@
 
 clean:
 	rm -rf $(program) $(obj)

--- a/src/bitcracker-hip/bitcracker.h
+++ b/src/bitcracker-hip/bitcracker.h
@@ -19,6 +19,9 @@
  * along with BitCracker. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef BITCRACKER_H
+#define BITCRACKER_H
+
 #include <hip/hip_runtime.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -111,3 +114,5 @@ int parse_data(char *input_hash, unsigned char ** salt, unsigned char ** nonce,	
 char * strtokm(char *s1, const char *delims);
 void attack(char *dname, uint32_t * d_w_words_uint32, unsigned char * encryptedVMK, unsigned char * nonce, unsigned char * encryptedMAC, int gridBlocks);
 void * Calloc(size_t len, size_t size);
+
+#endif


### PR DESCRIPTION
The bitcracker-hip build fails because utils.cpp (compiled from ../bitcracker-cuda/) includes bitcracker.h, which resolves to the CUDA variant's header containing `#include <cuda.h>`. The C standard specifies that `#include "..."` searches the source file's directory first, so `-I` flags cannot override this. In order to keep a single utils.cpp, this patch adds `-include bitcracker.h` directly into `utils.o` compile rule, so that the local HIP header is included. Then, this add include guards, so that the header from the CUDA directory becomes a no-op.