### PR TITLE
[logic-rewrite-hip] Fix memory ordering bug causing HSA_STATUS_ERROR_MEMORY_FAULT on MI300X

### DIFF
--- a/src/logic-rewrite-hip/rewrite.cu
+++ b/src/logic-rewrite-hip/rewrite.cu
@@ -335,11 +335,14 @@ __device__ void TableInsert(int in0, int in1, int C0, int C1, TableNode* hashTab
     key %= P;
     hashTable[P + index].val = idx;
     while(true) {
-        int res = atomicCAS(&hashTable[key].next, -1, P + index);
-        if(res == -1)
+        int expected = -1;
+        bool swapped = __hip_atomic_compare_exchange_strong(
+            &hashTable[key].next, &expected, P + index,
+            __ATOMIC_RELEASE, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+        if (swapped)
             break;
         else
-            key = res;
+            key = expected;
     }
 }
 
@@ -358,7 +361,9 @@ __device__ int TableLookup(int in0, int in1, int C0, int C1, TableNode* hashTabl
     key ^= C0 * 911;
     key ^= C1 * 353;
     key %= P;
-    for(int cur = hashTable[key].next; cur != -1; cur = hashTable[cur].next) {
+    for(int cur = __hip_atomic_load(&hashTable[key].next, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT);
+         cur != -1;
+         cur = __hip_atomic_load(&hashTable[cur].next, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_AGENT)) {
         int val = hashTable[cur].val;
         if(fanin0[val] == in0 && fanin1[val] == in1 && isC0[val] == C0 && isC1[val] == C1)
             return val;


### PR DESCRIPTION
The benchmark was crashing with HSA_STATUS_ERROR_MEMORY_FAULT on MI300X (gfx942). However, it was running fine on MI250X (gfx90a). According to my investigation, the problem is a missing memory ordering guarantee in the linked-list hash table used by the ReplaceSubgr kernel.

More specifically, `TableInsert` writes a `.val` using a plain store, and then publishes a pointer to that entry using `atomicCAS` on `.next`. `TableLookup` follows the `.next` chain, reads `.val`, and uses it as an index for some global arrays (e.g. fanin0, fanin1). On AMD GPUs, `atomicCAS` has relaxed memory ordering, which means that it guarantees atomicity of the CAS'd word, but does not order surrounding plain stores. This works for gfx90a because a single kernel runs on a single GCD with a shared L2 cache, so `.val` store likely propagates quickly enough that no thread ever observes a wrong value. However, on gfx942, a single kernel can run on up to 8 XCDs, each of them using their own L2. Under this scenario, a thread on one XCD can follow a valid `.next` pointer, while `.val` update wasn't propagated yet. The thread reads an unititialized `.val` and uses it as an array index, causing the memory fault.

To confirm the hypothesis above I added some instrumentation and extra checks to the kernel, and found that `.val = -1` was read hundreds of times, and later used as an index to the arrays mentioned above. After applying the fix, this never happened in 20+ runs.

The fix replaces the relaxed `atomicCAS` in `TableInsert` with a release-CAS (i.e. explicitly use `__ATOMIC_RELEASE` as order), and replaces plain load of `.next` in `TableLookup` with acquire-loads (i.e. explicit use of `__ATOMIC_ACQUIRE` as order). Both use `__HIP_MEMORY_SCOPE_AGENT` as scope, the narrowest scope that covers cross-XCD communication. The release on the CAS ensures all prior stores (including `.val`) are globally visible before `.next` is published. The acquire on the load ensures the reader sees those stores after following `.next`.

`__threadfence()` was also considered as an alternative, but the release-acquire approach handles this case more efficiently.

