### PR TITLE
[cc-hip] Fix flaky validation error caused by non-atomic store

### DIFF
--- a/src/cc-hip/main.cu
+++ b/src/cc-hip/main.cu
@@ -86,7 +86,7 @@ static inline __device__ int representative(const int idx, int* const __restrict
   if (curr != idx) {
     int next, prev = idx;
     while (curr > (next = nstat[curr])) {
-      nstat[prev] = next;
+      atomicExch(&nstat[prev], next);
       prev = curr;
       curr = next;
     }


### PR DESCRIPTION
The benchmark flaky fails validation on MI300x (gfx942): in my experiements, it failed validation in 8/110 runs. The problem is that `compute1`, `compute2` and `compute3` update `nstat[]` using `atomicCAS`, but all of them also call `representative()` which updates `nstat[prev]` using a plain store, causing a race condition. Instrumentation added to the benchmark showed that some nodes ended up pointing to an incorrect root as a result of the race condition, ultimately leading to the wrong result. The fix replaces the plain store with `atomicExch`, resulting in 110/110 successful runs.