### PR TITLE
[local-ht/rsmt] add hip to the models list in benchmarks.yaml

### DIFF
--- a/benchmarks.yaml
+++ b/benchmarks.yaml
@@ -1594,7 +1594,7 @@ linearprobing:
 
 local-ht:
   categories: [bioinformatics]
-  models: [cuda]
+  models: [cuda, hip]
   # No test metadata available
 
 log2:
@@ -2413,7 +2413,7 @@ rsc:
 
 rsmt:
   categories: [algorithms]
-  models: [cuda, sycl]
+  models: [cuda, hip, sycl]
   # No test metadata available
 
 rtm8:


### PR DESCRIPTION
Verified on AMD MI210 (gfx90a):
  local-ht-hip: all 4 kmer sizes (21/33/55/77) PASS self-validation
  rsmt-hip: newblue7.kraftwerk70.3d.80.20.82.m8.gr completes, 2635625 nets, 81M nets/sec, no errors