### PR TITLE
[axhelm][Fortran] fix: add libgfortran search path to linker flags

### DIFF
--- a/src/axhelm-cuda/Makefile
+++ b/src/axhelm-cuda/Makefile
@@ -28,12 +28,11 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Xcompiler -Wall -arch=$(ARCH) \
 # Linker Flags
 FC = gfortran
 
-ifneq ($(MAKECMDGOALS),clean)
-  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-  ifeq ($(wildcard $(LIBGFORTRAN)),)
-    $(error Could not find libgfortran using $(FC))
-  endif
-endif
+# Resolved on demand, so goals that do not link need no Fortran compiler.
+# $(FC) echoes the bare name when it cannot resolve the library, hence /%.
+LIBGFORTRAN_PATH = $(filter /%,$(shell $(FC) -print-file-name=libgfortran.so))
+LIBGFORTRAN = $(or $(wildcard $(LIBGFORTRAN_PATH)),\
+              $(error Could not find libgfortran using $(FC)))
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 

--- a/src/axhelm-cuda/Makefile
+++ b/src/axhelm-cuda/Makefile
@@ -26,7 +26,14 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Xcompiler -Wall -arch=$(ARCH) \
           -Ddfloat=float -Ddlong=int 
 
 # Linker Flags
-LDFLAGS = BlasLapack/libBlasLapack.a -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -44,7 +51,7 @@ endif
 #===============================================================================
 
 $(program): $(obj) BlasLapack/libBlasLapack.a 
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 main.o : main.cu axhelmKernel.cpp axhelmReference.cpp
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/axhelm-cuda/Makefile
+++ b/src/axhelm-cuda/Makefile
@@ -64,7 +64,7 @@ BlasLapack/libBlasLapack.a:
 	cd BlasLapack && make -j8 && cd ..
 
 clean:
-	cd BlasLapack && make clean && cd ..
+	if [ -d BlasLapack ]; then cd BlasLapack && make clean; fi
 	rm -rf $(program) $(obj)
 
 # run one- and three-dimensional kernels

--- a/src/axhelm-cuda/Makefile
+++ b/src/axhelm-cuda/Makefile
@@ -26,7 +26,7 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Xcompiler -Wall -arch=$(ARCH) \
           -Ddfloat=float -Ddlong=int 
 
 # Linker Flags
-FC ?= gfortran
+FC = gfortran
 LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
 ifeq ($(wildcard $(LIBGFORTRAN)),)

--- a/src/axhelm-cuda/Makefile
+++ b/src/axhelm-cuda/Makefile
@@ -27,10 +27,12 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Xcompiler -Wall -arch=$(ARCH) \
 
 # Linker Flags
 FC = gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
+ifneq ($(MAKECMDGOALS),clean)
+  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+  ifeq ($(wildcard $(LIBGFORTRAN)),)
+    $(error Could not find libgfortran using $(FC))
+  endif
 endif
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)

--- a/src/axhelm-hip/Makefile
+++ b/src/axhelm-hip/Makefile
@@ -26,10 +26,12 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
 
 # Linker Flags
 FC = gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
+ifneq ($(MAKECMDGOALS),clean)
+  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+  ifeq ($(wildcard $(LIBGFORTRAN)),)
+    $(error Could not find libgfortran using $(FC))
+  endif
 endif
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)

--- a/src/axhelm-hip/Makefile
+++ b/src/axhelm-hip/Makefile
@@ -63,7 +63,7 @@ BlasLapack/libBlasLapack.a:
 	cd BlasLapack && make -j8 && cd ..
 
 clean:
-	cd BlasLapack && make clean && cd ..
+	if [ -d BlasLapack ]; then cd BlasLapack && make clean; fi
 	rm -rf $(program) $(obj)
 
 # run one- and three-dimensional kernels

--- a/src/axhelm-hip/Makefile
+++ b/src/axhelm-hip/Makefile
@@ -25,7 +25,14 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-LDFLAGS = BlasLapack/libBlasLapack.a -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -43,7 +50,7 @@ endif
 # Targets to Build
 #===============================================================================
 $(program): $(obj) BlasLapack/libBlasLapack.a 
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 main.o : main.cu axhelmKernel.cpp ../axhelm-cuda/axhelmReference.cpp
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/axhelm-hip/Makefile
+++ b/src/axhelm-hip/Makefile
@@ -25,7 +25,7 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-FC ?= gfortran
+FC = gfortran
 LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
 ifeq ($(wildcard $(LIBGFORTRAN)),)

--- a/src/axhelm-hip/Makefile
+++ b/src/axhelm-hip/Makefile
@@ -27,12 +27,11 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
 # Linker Flags
 FC = gfortran
 
-ifneq ($(MAKECMDGOALS),clean)
-  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-  ifeq ($(wildcard $(LIBGFORTRAN)),)
-    $(error Could not find libgfortran using $(FC))
-  endif
-endif
+# Resolved on demand, so goals that do not link need no Fortran compiler.
+# $(FC) echoes the bare name when it cannot resolve the library, hence /%.
+LIBGFORTRAN_PATH = $(filter /%,$(shell $(FC) -print-file-name=libgfortran.so))
+LIBGFORTRAN = $(or $(wildcard $(LIBGFORTRAN_PATH)),\
+              $(error Could not find libgfortran using $(FC)))
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 

--- a/src/axhelm-omp/Makefile
+++ b/src/axhelm-omp/Makefile
@@ -26,7 +26,7 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-FC ?= gfortran
+FC = gfortran
 LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
 ifeq ($(wildcard $(LIBGFORTRAN)),)

--- a/src/axhelm-omp/Makefile
+++ b/src/axhelm-omp/Makefile
@@ -26,7 +26,14 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-LDFLAGS = BlasLapack/libBlasLapack.a -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -48,7 +55,7 @@ endif
 # Targets to Build
 #===============================================================================
 $(program): $(obj) BlasLapack/libBlasLapack.a 
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 main.o : main.cpp ../axhelm-cuda/axhelmReference.cpp
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/axhelm-omp/Makefile
+++ b/src/axhelm-omp/Makefile
@@ -28,12 +28,11 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
 # Linker Flags
 FC = gfortran
 
-ifneq ($(MAKECMDGOALS),clean)
-  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-  ifeq ($(wildcard $(LIBGFORTRAN)),)
-    $(error Could not find libgfortran using $(FC))
-  endif
-endif
+# Resolved on demand, so goals that do not link need no Fortran compiler.
+# $(FC) echoes the bare name when it cannot resolve the library, hence /%.
+LIBGFORTRAN_PATH = $(filter /%,$(shell $(FC) -print-file-name=libgfortran.so))
+LIBGFORTRAN = $(or $(wildcard $(LIBGFORTRAN_PATH)),\
+              $(error Could not find libgfortran using $(FC)))
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 

--- a/src/axhelm-omp/Makefile
+++ b/src/axhelm-omp/Makefile
@@ -68,7 +68,7 @@ BlasLapack/libBlasLapack.a:
 	cd BlasLapack && make -j8 && cd ..
 
 clean:
-	cd BlasLapack && make clean && cd ..
+	if [ -d BlasLapack ]; then cd BlasLapack && make clean; fi
 	rm -rf $(program) $(obj)
 
 # run one- and three-dimensional kernels

--- a/src/axhelm-omp/Makefile
+++ b/src/axhelm-omp/Makefile
@@ -27,10 +27,12 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
 
 # Linker Flags
 FC = gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
+ifneq ($(MAKECMDGOALS),clean)
+  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+  ifeq ($(wildcard $(LIBGFORTRAN)),)
+    $(error Could not find libgfortran using $(FC))
+  endif
 endif
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)

--- a/src/axhelm-omp/Makefile.aomp
+++ b/src/axhelm-omp/Makefile.aomp
@@ -27,7 +27,7 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-FC ?= gfortran
+FC = gfortran
 LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
 ifeq ($(wildcard $(LIBGFORTRAN)),)

--- a/src/axhelm-omp/Makefile.aomp
+++ b/src/axhelm-omp/Makefile.aomp
@@ -28,10 +28,12 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
 
 # Linker Flags
 FC = gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
+ifneq ($(MAKECMDGOALS),clean)
+  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+  ifeq ($(wildcard $(LIBGFORTRAN)),)
+    $(error Could not find libgfortran using $(FC))
+  endif
 endif
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)

--- a/src/axhelm-omp/Makefile.aomp
+++ b/src/axhelm-omp/Makefile.aomp
@@ -72,7 +72,7 @@ BlasLapack/libBlasLapack.a:
 	cd BlasLapack && make -j8 && cd ..
 
 clean:
-	cd BlasLapack && make clean && cd ..
+	if [ -d BlasLapack ]; then cd BlasLapack && make clean; fi
 	rm -rf $(program) $(obj)
 
 # run one- and three-dimensional kernels

--- a/src/axhelm-omp/Makefile.aomp
+++ b/src/axhelm-omp/Makefile.aomp
@@ -27,7 +27,14 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-LDFLAGS = BlasLapack/libBlasLapack.a -L$(shell dirname $(shell gcc -print-file-name=libgfortran.so)) -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -52,7 +59,7 @@ endif
 # Targets to Build
 #===============================================================================
 $(program): $(obj) BlasLapack/libBlasLapack.a 
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 main.o : main.cpp ../axhelm-cuda/axhelmReference.cpp
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/axhelm-omp/Makefile.aomp
+++ b/src/axhelm-omp/Makefile.aomp
@@ -29,12 +29,11 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
 # Linker Flags
 FC = gfortran
 
-ifneq ($(MAKECMDGOALS),clean)
-  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-  ifeq ($(wildcard $(LIBGFORTRAN)),)
-    $(error Could not find libgfortran using $(FC))
-  endif
-endif
+# Resolved on demand, so goals that do not link need no Fortran compiler.
+# $(FC) echoes the bare name when it cannot resolve the library, hence /%.
+LIBGFORTRAN_PATH = $(filter /%,$(shell $(FC) -print-file-name=libgfortran.so))
+LIBGFORTRAN = $(or $(wildcard $(LIBGFORTRAN_PATH)),\
+              $(error Could not find libgfortran using $(FC)))
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 

--- a/src/axhelm-omp/Makefile.aomp
+++ b/src/axhelm-omp/Makefile.aomp
@@ -27,7 +27,7 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-LDFLAGS = BlasLapack/libBlasLapack.a -lgfortran
+LDFLAGS = BlasLapack/libBlasLapack.a -L$(shell dirname $(shell gcc -print-file-name=libgfortran.so)) -lgfortran
 
 # Debug Flags
 ifeq ($(DEBUG),yes)

--- a/src/axhelm-omp/Makefile.nvc
+++ b/src/axhelm-omp/Makefile.nvc
@@ -27,7 +27,7 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-FC ?= gfortran
+FC = gfortran
 LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
 ifeq ($(wildcard $(LIBGFORTRAN)),)

--- a/src/axhelm-omp/Makefile.nvc
+++ b/src/axhelm-omp/Makefile.nvc
@@ -69,7 +69,7 @@ BlasLapack/libBlasLapack.a:
 	cd BlasLapack && make -j8 && cd ..
 
 clean:
-	cd BlasLapack && make clean && cd ..
+	if [ -d BlasLapack ]; then cd BlasLapack && make clean; fi
 	rm -rf $(program) $(obj)
 
 # run one- and three-dimensional kernels

--- a/src/axhelm-omp/Makefile.nvc
+++ b/src/axhelm-omp/Makefile.nvc
@@ -27,7 +27,14 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Wall -Ddfloat=float -Ddlong=int \
           -I../axhelm-cuda
 
 # Linker Flags
-LDFLAGS = BlasLapack/libBlasLapack.a -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -49,7 +56,7 @@ endif
 # Targets to Build
 #===============================================================================
 $(program): $(obj) BlasLapack/libBlasLapack.a 
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 main.o : main.cpp ../axhelm-cuda/axhelmReference.cpp
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/axhelm-omp/Makefile.nvc
+++ b/src/axhelm-omp/Makefile.nvc
@@ -29,12 +29,11 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Wall -Ddfloat=float -Ddlong=int \
 # Linker Flags
 FC = gfortran
 
-ifneq ($(MAKECMDGOALS),clean)
-  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-  ifeq ($(wildcard $(LIBGFORTRAN)),)
-    $(error Could not find libgfortran using $(FC))
-  endif
-endif
+# Resolved on demand, so goals that do not link need no Fortran compiler.
+# $(FC) echoes the bare name when it cannot resolve the library, hence /%.
+LIBGFORTRAN_PATH = $(filter /%,$(shell $(FC) -print-file-name=libgfortran.so))
+LIBGFORTRAN = $(or $(wildcard $(LIBGFORTRAN_PATH)),\
+              $(error Could not find libgfortran using $(FC)))
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 

--- a/src/axhelm-omp/Makefile.nvc
+++ b/src/axhelm-omp/Makefile.nvc
@@ -28,10 +28,12 @@ CFLAGS := $(EXTRA_CFLAGS) -std=c++14 -Wall -Ddfloat=float -Ddlong=int \
 
 # Linker Flags
 FC = gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
+ifneq ($(MAKECMDGOALS),clean)
+  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+  ifeq ($(wildcard $(LIBGFORTRAN)),)
+    $(error Could not find libgfortran using $(FC))
+  endif
 endif
 
 LDLIBS = BlasLapack/libBlasLapack.a $(LIBGFORTRAN)

--- a/src/axhelm-sycl/Makefile
+++ b/src/axhelm-sycl/Makefile
@@ -40,12 +40,11 @@ endif
 # Linker Flags
 FC = gfortran
 
-ifneq ($(MAKECMDGOALS),clean)
-  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-  ifeq ($(wildcard $(LIBGFORTRAN)),)
-    $(error Could not find libgfortran using $(FC))
-  endif
-endif
+# Resolved on demand, so goals that do not link need no Fortran compiler.
+# $(FC) echoes the bare name when it cannot resolve the library, hence /%.
+LIBGFORTRAN_PATH = $(filter /%,$(shell $(FC) -print-file-name=libgfortran.so))
+LIBGFORTRAN = $(or $(wildcard $(LIBGFORTRAN_PATH)),\
+              $(error Could not find libgfortran using $(FC)))
 
 LDLIBS = ./BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 

--- a/src/axhelm-sycl/Makefile
+++ b/src/axhelm-sycl/Makefile
@@ -38,7 +38,7 @@ ifeq ($(VENDOR), AdaptiveCpp)
 endif
 
 # Linker Flags
-FC ?= gfortran
+FC = gfortran
 LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
 ifeq ($(wildcard $(LIBGFORTRAN)),)

--- a/src/axhelm-sycl/Makefile
+++ b/src/axhelm-sycl/Makefile
@@ -39,10 +39,12 @@ endif
 
 # Linker Flags
 FC = gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
 
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
+ifneq ($(MAKECMDGOALS),clean)
+  LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+  ifeq ($(wildcard $(LIBGFORTRAN)),)
+    $(error Could not find libgfortran using $(FC))
+  endif
 endif
 
 LDLIBS = ./BlasLapack/libBlasLapack.a $(LIBGFORTRAN)

--- a/src/axhelm-sycl/Makefile
+++ b/src/axhelm-sycl/Makefile
@@ -38,7 +38,14 @@ ifeq ($(VENDOR), AdaptiveCpp)
 endif
 
 # Linker Flags
-LDFLAGS = ./BlasLapack/libBlasLapack.a -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = ./BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 ifeq ($(CUDA), yes)
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
@@ -69,7 +76,7 @@ endif
 #===============================================================================
 
 $(program): $(obj) BlasLapack/libBlasLapack.a
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 main.o : main.cpp ../axhelm-cuda/axhelmReference.cpp
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/src/axhelm-sycl/Makefile.hipsycl
+++ b/src/axhelm-sycl/Makefile.hipsycl
@@ -27,7 +27,14 @@ CFLAGS := $(EXTRA_CFLAGS) -Wall -I../include \
 	  --hipsycl-gpu-arch=$(MARCH)
 
 # Linker Flags
-LDFLAGS = ./BlasLapack/libBlasLapack.a -lgfortran
+FC ?= gfortran
+LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
+
+ifeq ($(wildcard $(LIBGFORTRAN)),)
+$(error Could not find libgfortran using $(FC))
+endif
+
+LDLIBS = ./BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -59,7 +66,7 @@ meshBasis.o : meshBasis.cpp meshBasis.hpp meshNodesTet3D.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(program): main.o meshBasis.o
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
 
 clean:
 	rm -rf $(program) main.o meshBasis.o

--- a/src/axhelm-sycl/Makefile.hipsycl
+++ b/src/axhelm-sycl/Makefile.hipsycl
@@ -27,14 +27,7 @@ CFLAGS := $(EXTRA_CFLAGS) -Wall -I../include \
 	  --hipsycl-gpu-arch=$(MARCH)
 
 # Linker Flags
-FC ?= gfortran
-LIBGFORTRAN := $(shell $(FC) -print-file-name=libgfortran.so)
-
-ifeq ($(wildcard $(LIBGFORTRAN)),)
-$(error Could not find libgfortran using $(FC))
-endif
-
-LDLIBS = ./BlasLapack/libBlasLapack.a $(LIBGFORTRAN)
+LDFLAGS = ./BlasLapack/libBlasLapack.a -lgfortran
 
 # Debug Flags
 ifeq ($(DEBUG),yes)
@@ -66,7 +59,7 @@ meshBasis.o : meshBasis.cpp meshBasis.hpp meshNodesTet3D.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(program): main.o meshBasis.o
-	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS) $(LDLIBS)
+	$(CC) $(CFLAGS) $+ -o $@ $(LDFLAGS)
 
 clean:
 	rm -rf $(program) main.o meshBasis.o


### PR DESCRIPTION
The linker cannot find libgfortran when it is not in the default search path.
Use gcc -print-file-name to discover the correct -L directory.

Assisted-by: Claude Opus 4.6