### PR TITLE
[Makefile][clean] fix: scope rm globs to prevent deleting tracked files

### DIFF
--- a/src/grrt-cuda/Makefile
+++ b/src/grrt-cuda/Makefile
@@ -52,7 +52,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj) Output_task1.txt Output_task2.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program)

--- a/src/grrt-hip/Makefile
+++ b/src/grrt-hip/Makefile
@@ -51,7 +51,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj) Output_task1.txt Output_task2.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program)

--- a/src/grrt-omp/Makefile
+++ b/src/grrt-omp/Makefile
@@ -57,7 +57,7 @@ $(program): $(obj)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj) Output_task1.txt Output_task2.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program)

--- a/src/grrt-omp/Makefile.aomp
+++ b/src/grrt-omp/Makefile.aomp
@@ -61,7 +61,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj) Output_task1.txt Output_task2.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program)

--- a/src/grrt-omp/Makefile.nvc
+++ b/src/grrt-omp/Makefile.nvc
@@ -57,7 +57,7 @@ $(program): $(obj)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj) Output_task1.txt Output_task2.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program)

--- a/src/grrt-sycl/Makefile
+++ b/src/grrt-sycl/Makefile
@@ -75,7 +75,7 @@ $(program): $(obj)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj) Output_task1.txt Output_task2.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program)

--- a/src/iso2dfd-cuda/Makefile
+++ b/src/iso2dfd-cuda/Makefile
@@ -52,7 +52,7 @@ $(program): $(obj) iso2dfd.h Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.bin *.txt
+	rm -rf $(program) $(obj) *.bin error_diff.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 2048 2048 1000

--- a/src/iso2dfd-hip/Makefile
+++ b/src/iso2dfd-hip/Makefile
@@ -51,7 +51,7 @@ $(program): $(obj) iso2dfd.h Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.bin *.txt
+	rm -rf $(program) $(obj) *.bin error_diff.txt
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 2048 2048 1000

--- a/src/iso2dfd-omp/Makefile
+++ b/src/iso2dfd-omp/Makefile
@@ -56,7 +56,7 @@ $(program): $(obj) iso2dfd.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt *.bin
+	rm -rf $(program) $(obj) error_diff.txt *.bin
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 2048 2048 1000

--- a/src/iso2dfd-omp/Makefile.aomp
+++ b/src/iso2dfd-omp/Makefile.aomp
@@ -61,7 +61,7 @@ $(program): $(obj) iso2dfd.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt *.bin
+	rm -rf $(program) $(obj) error_diff.txt *.bin
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 2048 2048 1000

--- a/src/iso2dfd-omp/Makefile.nvc
+++ b/src/iso2dfd-omp/Makefile.nvc
@@ -58,7 +58,7 @@ $(program): $(obj) iso2dfd.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt *.bin
+	rm -rf $(program) $(obj) error_diff.txt *.bin
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 2048 2048 1000

--- a/src/iso2dfd-sycl/Makefile
+++ b/src/iso2dfd-sycl/Makefile
@@ -75,7 +75,7 @@ $(program): $(obj)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt *.bin
+	rm -rf $(program) $(obj) error_diff.txt *.bin
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 2048 2048 1000

--- a/src/mpc-cuda/Makefile
+++ b/src/mpc-cuda/Makefile
@@ -50,7 +50,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt fpc
+	rm -rf $(program) $(obj) compression.txt decompression.txt fpc
 
 process: fpc.c
 	gcc -O3 fpc.c -o fpc

--- a/src/mpc-hip/Makefile
+++ b/src/mpc-hip/Makefile
@@ -49,7 +49,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt fpc
+	rm -rf $(program) $(obj) compression.txt decompression.txt fpc
 
 run: $(program)
         # compression

--- a/src/mpc-sycl/Makefile
+++ b/src/mpc-sycl/Makefile
@@ -76,7 +76,7 @@ $(program): $(obj)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt fpc
+	rm -rf $(program) $(obj) compression.txt decompression.txt fpc
 
 run: $(program)
         # compression

--- a/src/pcc-cuda/Makefile
+++ b/src/pcc-cuda/Makefile
@@ -53,7 +53,7 @@ $(program): $(obj) Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj)
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 90112 165

--- a/src/pcc-hip/Makefile
+++ b/src/pcc-hip/Makefile
@@ -53,7 +53,7 @@ device.o: device.cu ../pcc-cuda/device.h Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj)
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 90112 165

--- a/src/pcc-sycl/Makefile
+++ b/src/pcc-sycl/Makefile
@@ -91,7 +91,7 @@ device.o: device.cpp ../pcc-cuda/device.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj)
 
 run: $(program)
 	$(LAUNCHER) ./$(program) 90112 165

--- a/src/recursiveGaussian-hip/Makefile
+++ b/src/recursiveGaussian-hip/Makefile
@@ -60,7 +60,7 @@ shrUtils.o : ../boxfilter-sycl/shrUtils.cpp ../boxfilter-sycl/shrUtils.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.txt
+	rm -rf $(program) $(obj)
 
 run: $(program)
 	$(LAUNCHER) ./$(program) ../recursiveGaussian-cuda/StoneRGB.ppm 1000

--- a/src/tridiagonal-cuda/Makefile
+++ b/src/tridiagonal-cuda/Makefile
@@ -69,7 +69,7 @@ cmd_arg_reader.o: cmd_arg_reader.cu cmd_arg_reader.h exception.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.dat *.timing *.txt *.csv
+	rm -rf $(program) $(obj) *.dat *.timing oclTridiagonal.txt SdkConsoleLog.txt *.csv
 
 run: $(program)
 	$(LAUNCHER) ./$(program) -num_systems=524288

--- a/src/tridiagonal-hip/Makefile
+++ b/src/tridiagonal-hip/Makefile
@@ -67,7 +67,7 @@ cmd_arg_reader.o: cmd_arg_reader.cu cmd_arg_reader.h exception.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.dat *.timing *.txt *.csv
+	rm -rf $(program) $(obj) *.dat *.timing oclTridiagonal.txt SdkConsoleLog.txt *.csv
 
 run: $(program)
 	$(LAUNCHER) ./$(program) -num_systems=524288

--- a/src/tridiagonal-omp/Makefile
+++ b/src/tridiagonal-omp/Makefile
@@ -75,7 +75,7 @@ cmd_arg_reader.o: cmd_arg_reader.cpp cmd_arg_reader.h exception.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.dat *.timing *.txt *.csv
+	rm -rf $(program) $(obj) *.dat *.timing oclTridiagonal.txt SdkConsoleLog.txt *.csv
 
 run: $(program)
 	$(LAUNCHER) ./$(program) -num_systems=524288

--- a/src/tridiagonal-omp/Makefile.aomp
+++ b/src/tridiagonal-omp/Makefile.aomp
@@ -79,7 +79,7 @@ cmd_arg_reader.o: cmd_arg_reader.cpp cmd_arg_reader.h exception.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.dat *.timing *.txt *.csv
+	rm -rf $(program) $(obj) *.dat *.timing oclTridiagonal.txt SdkConsoleLog.txt *.csv
 
 run: $(program)
 	$(LAUNCHER) ./$(program) -num_systems=524288

--- a/src/tridiagonal-omp/Makefile.nvc
+++ b/src/tridiagonal-omp/Makefile.nvc
@@ -76,7 +76,7 @@ cmd_arg_reader.o: cmd_arg_reader.cpp cmd_arg_reader.h exception.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.dat *.timing *.txt *.csv
+	rm -rf $(program) $(obj) *.dat *.timing oclTridiagonal.txt SdkConsoleLog.txt *.csv
 
 run: $(program)
 	$(LAUNCHER) ./$(program) -num_systems=524288

--- a/src/tridiagonal-sycl/Makefile
+++ b/src/tridiagonal-sycl/Makefile
@@ -93,7 +93,7 @@ cmd_arg_reader.o: cmd_arg_reader.cpp cmd_arg_reader.h exception.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(program) $(obj) *.dat *.timing *.txt *.csv
+	rm -rf $(program) $(obj) *.dat *.timing oclTridiagonal.txt SdkConsoleLog.txt *.csv
 
 run: $(program)
 	$(LAUNCHER) ./$(program) -num_systems=524288


### PR DESCRIPTION
Six benchmark families (grrt, iso2dfd, mpc, pcc, recursiveGaussian, tridiagonal) use `rm -rf *.txt` in their clean rules.
This deletes tracked files like CMakeLists.txt and output files produced by sibling variant runs.
Replace with the explicit filenames each benchmark produces.

AI-assisted.