### PR TITLE
[zeropoint][omp] fix: add -I../zeropoint-cuda for shared headers

### DIFF
--- a/src/zeropoint-omp/Makefile.aomp
+++ b/src/zeropoint-omp/Makefile.aomp
@@ -25,7 +25,7 @@ obj = $(source:.cpp=.o)
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall 
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../zeropoint-cuda
 
 # Linker Flags
 LDFLAGS = 


### PR DESCRIPTION
The OMP variant includes headers from the CUDA variant's directory but Makefile.aomp lacks the corresponding -I flag, causing a build failure.

AI-assisted.