### PR TITLE
[divergence][omp] fix: remove nonexistent timer.o dependency

### DIFF
--- a/src/divergence-omp/Makefile.aomp
+++ b/src/divergence-omp/Makefile.aomp
@@ -50,15 +50,11 @@ endif
 # Targets to Build
 #===============================================================================
 
-$(program): divergence.o timer.o 
+$(program): divergence.o
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 divergence.o: divergence.cpp divergence.hpp Makefile
 	$(CC) $(CFLAGS) -c $< -o $@
-
-timer.o: timer/timer.cpp timer/timer.hpp
-	$(CC) $(CFLAGS) -c $< -o $@
-
 
 clean:
 	rm -rf $(program) *.o


### PR DESCRIPTION
Makefile.aomp links timer/timer.cpp which does not exist in the source tree.
The divergence benchmark does not use timer functions; the rule was likely copied from another benchmark's template.

AI-assisted.