### PR TITLE
[miniFE][omp] fix: add root Makefile.aomp as build entry point

### DIFF
--- a/src/miniFE-omp/Makefile
+++ b/src/miniFE-omp/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all clean run
+
+all:
+	$(MAKE) -C src
+
+clean:
+	$(MAKE) -C src clean
+
+run: all
+	cd src && ./main -nx 128 -ny 128 -nz 128

--- a/src/miniFE-omp/Makefile.aomp
+++ b/src/miniFE-omp/Makefile.aomp
@@ -1,0 +1,14 @@
+.PHONY: all clean run
+
+ARCH         ?= gfx906
+EXTRA_CFLAGS ?=
+LAUNCHER     ?=
+
+all:
+	$(MAKE) -C src -f Makefile.aomp ARCH=$(ARCH) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
+
+clean:
+	$(MAKE) -C src -f Makefile.aomp clean
+
+run: all
+	cd src && $(LAUNCHER) ./main -nx 128 -ny 128 -nz 128


### PR DESCRIPTION
The AOMP runner invokes make in the benchmark's top-level directory, but miniFE's build lives in src/.
Add a thin wrapper that forwards to src/Makefile.aomp, passing ARCH and EXTRA_CFLAGS through and running the binary under $(LAUNCHER) -- matching the pattern of other multi-directory benchmarks (e.g. tridiagonal).

AI-assisted.