### PR TITLE
[xlqc][omp] fix: discover GSL paths via gsl-config

### DIFF
--- a/src/xlqc-cuda/Makefile
+++ b/src/xlqc-cuda/Makefile
@@ -7,10 +7,13 @@ CC        = nvcc
 OPTIMIZE  = yes
 DEBUG     = no
 ARCH      = sm_60
-GSL_INC   =-I/path/to/gsl/include
-GSL_LIB   =-L/path/to/gsl/lib -lgsl -lgslcblas 
+GSL_INC   ?= $(shell gsl-config --cflags)
+GSL_LIB   ?= $(shell gsl-config --libs)
 LAUNCHER  =
 
+ifeq ($(GSL_LIB),)
+$(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
+endif
 
 #===============================================================================
 # Program name & source code list

--- a/src/xlqc-hip/Makefile
+++ b/src/xlqc-hip/Makefile
@@ -6,10 +6,13 @@
 CC        = hipcc
 OPTIMIZE  = yes
 DEBUG     = no
-GSL_INC   =-I/path/to/gsl/include
-GSL_LIB   =-L/path/to/gsl/lib -lgsl -lgslcblas 
+GSL_INC   ?= $(shell gsl-config --cflags)
+GSL_LIB   ?= $(shell gsl-config --libs)
 LAUNCHER  =
 
+ifeq ($(GSL_LIB),)
+$(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
+endif
 
 #===============================================================================
 # Program name & source code list

--- a/src/xlqc-omp/Makefile
+++ b/src/xlqc-omp/Makefile
@@ -7,10 +7,13 @@ CC        = icpx
 OPTIMIZE  = yes
 DEBUG     = no
 DEVICE    = gpu
-GSL_INC   =-I/path/to/gsl/include
-GSL_LIB   =-L/path/to/gsl/lib -lgsl -lgslcblas 
+GSL_INC   ?= $(shell gsl-config --cflags)
+GSL_LIB   ?= $(shell gsl-config --libs)
 LAUNCHER  =
 
+ifeq ($(GSL_LIB),)
+$(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
+endif
 
 #===============================================================================
 # Program name & source code list

--- a/src/xlqc-omp/Makefile.aomp
+++ b/src/xlqc-omp/Makefile.aomp
@@ -8,8 +8,12 @@ OPTIMIZE  = yes
 DEBUG     = no
 DEVICE    = gpu
 ARCH      = gfx906
-GSL_INC   =$(shell gsl-config --cflags 2>/dev/null)
-GSL_LIB   =$(shell gsl-config --libs 2>/dev/null)
+GSL_INC   ?= $(shell gsl-config --cflags)
+GSL_LIB   ?= $(shell gsl-config --libs)
+
+ifeq ($(GSL_LIB),)
+$(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
+endif
 LAUNCHER  =
 
 

--- a/src/xlqc-omp/Makefile.aomp
+++ b/src/xlqc-omp/Makefile.aomp
@@ -8,8 +8,8 @@ OPTIMIZE  = yes
 DEBUG     = no
 DEVICE    = gpu
 ARCH      = gfx906
-GSL_INC   =-I/path/to/gsl/include
-GSL_LIB   =-L/path/to/gsl/lib -lgsl -lgslcblas 
+GSL_INC   =$(shell gsl-config --cflags 2>/dev/null)
+GSL_LIB   =$(shell gsl-config --libs 2>/dev/null)
 LAUNCHER  =
 
 

--- a/src/xlqc-omp/Makefile.aomp
+++ b/src/xlqc-omp/Makefile.aomp
@@ -10,12 +10,11 @@ DEVICE    = gpu
 ARCH      = gfx906
 GSL_INC   ?= $(shell gsl-config --cflags)
 GSL_LIB   ?= $(shell gsl-config --libs)
+LAUNCHER  =
 
 ifeq ($(GSL_LIB),)
 $(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
 endif
-LAUNCHER  =
-
 
 #===============================================================================
 # Program name & source code list

--- a/src/xlqc-omp/Makefile.nvc
+++ b/src/xlqc-omp/Makefile.nvc
@@ -8,10 +8,13 @@ OPTIMIZE  = yes
 DEBUG     = no
 DEVICE    = gpu
 SM        = cc70
-GSL_INC   =-I/path/to/gsl/include
-GSL_LIB   =-L/path/to/gsl/lib -lgsl -lgslcblas 
+GSL_INC   ?= $(shell gsl-config --cflags)
+GSL_LIB   ?= $(shell gsl-config --libs)
 LAUNCHER  =
 
+ifeq ($(GSL_LIB),)
+$(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
+endif
 
 #===============================================================================
 # Program name & source code list

--- a/src/xlqc-sycl/Makefile
+++ b/src/xlqc-sycl/Makefile
@@ -6,8 +6,8 @@
 CC        = clang++
 OPTIMIZE  = yes
 DEBUG     = no
-GSL_INC   =-I/path/to/gsl/include
-GSL_LIB   =-L/path/to/gsl/lib -lgsl -lgslcblas 
+GSL_INC   ?= $(shell gsl-config --cflags)
+GSL_LIB   ?= $(shell gsl-config --libs)
 LAUNCHER  =
 
 GPU       = yes
@@ -16,6 +16,10 @@ CUDA_ARCH = sm_70
 HIP       = no
 HIP_ARCH  = gfx908
 #GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
+
+ifeq ($(GSL_LIB),)
+$(error gsl-config not found; install libgsl-dev or set GSL_INC/GSL_LIB)
+endif
 
 #===============================================================================
 # Program name & source code list


### PR DESCRIPTION
GSL_INC and GSL_LIB were hardcoded placeholders ("/path/to/gsl/...").
Use gsl-config to discover the installed GSL at build time.

Assisted-by: Claude Opus 4.6 / 5