### PR TITLE
[miniFE][omp] fix: propagate EXTRA_CFLAGS to inner Makefile.aomp

### DIFF
--- a/src/miniFE-omp/src/Makefile.aomp
+++ b/src/miniFE-omp/src/Makefile.aomp
@@ -12,7 +12,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-CFLAGS += -v -O3 -target x86_64-pc-linux-gnu \
+CFLAGS += $(EXTRA_CFLAGS) -v -O3 -target x86_64-pc-linux-gnu \
           -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
           -Xopenmp-target=amdgcn-amd-amdhsa \
           -march=$(ARCH) \


### PR DESCRIPTION
The inner Makefile.aomp ignores EXTRA_CFLAGS, so flags passed from the runner (e.g. offload-arch, fp32 lowering) have no effect on the build.
Prepend $(EXTRA_CFLAGS) to CFLAGS, matching every other Makefile.aomp.

AI-assisted.