### PR TITLE
[pointerchase-hip] Do not use statements with side-effects within assert

### DIFF
--- a/src/pointerchase-hip/main.cu
+++ b/src/pointerchase-hip/main.cu
@@ -57,9 +57,9 @@ void ptrChasingKernel(struct LatencyNode *data,
     p = p->next;
   }
 
-  // avoid compiler optimization
+  // avoid compiler optimization — must not use assert() (disabled by -DNDEBUG)
   if (p == nullptr) {
-    assert(0); //__trap();
+    __builtin_trap();
   }
 }
 


### PR DESCRIPTION
Release builds frequently define `NDEBUG`, which disables `assert`. As a consequence, everything within `assert` doesn't run.