### PR TITLE
[inversek2j][omp] fix: typo in relative path

### DIFF
--- a/src/inversek2j-omp/Makefile.aomp
+++ b/src/inversek2j-omp/Makefile.aomp
@@ -64,4 +64,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) ../inverse2kj-sycl/coord_in.txt 100000
+	$(LAUNCHER) ./$(program) ../inversek2j-sycl/coord_in.txt 100000

--- a/src/inversek2j-omp/Makefile.nvc
+++ b/src/inversek2j-omp/Makefile.nvc
@@ -61,4 +61,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) ../inverse2kj-sycl/coord_in.txt 100000
+	$(LAUNCHER) ./$(program) ../inversek2j-sycl/coord_in.txt 100000


### PR DESCRIPTION
run command referenced `inverse2kj` instead of `inversek2j`.