### PR TITLE
[miniFE] add build entry points for the OpenMP version and honor LAUNCHER in all variants

### DIFF
--- a/src/miniFE-cuda/Makefile
+++ b/src/miniFE-cuda/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean realclean run
 
-LAUNCHER  =
+LAUNCHER  ?=
 
 all:
 	$(MAKE) -C src

--- a/src/miniFE-cuda/src/Makefile
+++ b/src/miniFE-cuda/src/Makefile
@@ -45,7 +45,6 @@ LIBS=
 
 CXX=nvcc
 CC=nvcc
-LAUNCHER  =
 
 #CXX=xlC
 #CC=xlc

--- a/src/miniFE-hip/Makefile
+++ b/src/miniFE-hip/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean realclean run
 
-LAUNCHER  =
+LAUNCHER  ?=
 
 all:
 	$(MAKE) -C src

--- a/src/miniFE-hip/Makefile
+++ b/src/miniFE-hip/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all clean run
+.PHONY: all clean realclean run
+
+LAUNCHER  =
 
 all:
 	$(MAKE) -C src
@@ -6,7 +8,10 @@ all:
 clean:
 	$(MAKE) -C src clean
 
-# src/Makefile builds miniFE.x but doesn't define a `run:` target; invoke
-# the binary directly with a small default problem size.
+realclean:
+	$(MAKE) -C src realclean
+
+# Run from src/: miniFE writes its .yaml report into the working directory,
+# and only realclean removes it.
 run: all
-	cd src && ./main -nx 128 -ny 128 -nz 128
+	cd src && $(LAUNCHER) ./main -nx 128 -ny 128 -nz 128

--- a/src/miniFE-hip/src/Makefile
+++ b/src/miniFE-hip/src/Makefile
@@ -43,7 +43,6 @@ LIBS=
 
 CXX=hipcc
 CC=hipcc
-LAUNCHER  =
 
 #CXX=xlC
 #CC=xlc

--- a/src/miniFE-omp/Makefile
+++ b/src/miniFE-omp/Makefile
@@ -3,7 +3,7 @@
 LAUNCHER  =
 
 all:
-	$(MAKE) -C src
+	$(MAKE) -C src EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
 
 clean:
 	$(MAKE) -C src clean

--- a/src/miniFE-omp/Makefile
+++ b/src/miniFE-omp/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean realclean run
 
-LAUNCHER  =
+LAUNCHER  ?=
 
 all:
 	$(MAKE) -C src EXTRA_CFLAGS="$(EXTRA_CFLAGS)"

--- a/src/miniFE-omp/Makefile.aomp
+++ b/src/miniFE-omp/Makefile.aomp
@@ -1,7 +1,7 @@
 .PHONY: all clean realclean run
 
 ARCH      = gfx906
-LAUNCHER  =
+LAUNCHER  ?=
 
 all:
 	$(MAKE) -C src -f Makefile.aomp ARCH=$(ARCH) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"

--- a/src/miniFE-omp/Makefile.aomp
+++ b/src/miniFE-omp/Makefile.aomp
@@ -1,15 +1,16 @@
 .PHONY: all clean realclean run
 
+ARCH      = gfx906
 LAUNCHER  =
 
 all:
-	$(MAKE) -C src
+	$(MAKE) -C src -f Makefile.aomp ARCH=$(ARCH) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
 
 clean:
-	$(MAKE) -C src clean
+	$(MAKE) -C src -f Makefile.aomp clean
 
 realclean:
-	$(MAKE) -C src realclean
+	$(MAKE) -C src -f Makefile.aomp realclean
 
 # Run from src/: miniFE writes its .yaml report into the working directory,
 # and only realclean removes it.

--- a/src/miniFE-omp/Makefile.nvc
+++ b/src/miniFE-omp/Makefile.nvc
@@ -1,7 +1,7 @@
 .PHONY: all clean realclean run
 
-SM        = cc70
-LAUNCHER  =
+SM        ?= cc70
+LAUNCHER  ?=
 
 all:
 	$(MAKE) -C src -f Makefile.nvc SM=$(SM) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"

--- a/src/miniFE-omp/Makefile.nvc
+++ b/src/miniFE-omp/Makefile.nvc
@@ -1,15 +1,16 @@
 .PHONY: all clean realclean run
 
+SM        = cc70
 LAUNCHER  =
 
 all:
-	$(MAKE) -C src
+	$(MAKE) -C src -f Makefile.nvc SM=$(SM) EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
 
 clean:
-	$(MAKE) -C src clean
+	$(MAKE) -C src -f Makefile.nvc clean
 
 realclean:
-	$(MAKE) -C src realclean
+	$(MAKE) -C src -f Makefile.nvc realclean
 
 # Run from src/: miniFE writes its .yaml report into the working directory,
 # and only realclean removes it.

--- a/src/miniFE-omp/src/Makefile
+++ b/src/miniFE-omp/src/Makefile
@@ -12,7 +12,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-CFLAGS = -v -O3 -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__\
+CFLAGS = $(EXTRA_CFLAGS) -v -O3 -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__\
 	-ffp-contract=fast 
 #	-S -emit-llvm
 #\
@@ -41,7 +41,6 @@ LIBS=
 
 CXX=icpx
 CC=icc
-LAUNCHER  =
 
 #CXX=clang++
 #CC=clang

--- a/src/miniFE-omp/src/Makefile.aomp
+++ b/src/miniFE-omp/src/Makefile.aomp
@@ -44,7 +44,6 @@ LIBS=
 
 CXX=clang++
 CC=clang
-LAUNCHER  =
 
 #CXX=xlC
 #CC=xlc

--- a/src/miniFE-omp/src/Makefile.nvc
+++ b/src/miniFE-omp/src/Makefile.nvc
@@ -12,7 +12,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-SM = cc70
+SM ?= cc70
 CFLAGS = $(EXTRA_CFLAGS) -v -O3 -Minfo -mp=gpu -gpu=$(SM),fastmath
 #	-S -emit-llvm
 #\

--- a/src/miniFE-omp/src/Makefile.nvc
+++ b/src/miniFE-omp/src/Makefile.nvc
@@ -12,7 +12,8 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-CFLAGS = -v -O3 -Minfo -mp=gpu -gpu=cc70,fastmath
+SM = cc70
+CFLAGS = $(EXTRA_CFLAGS) -v -O3 -Minfo -mp=gpu -gpu=$(SM),fastmath
 #	-S -emit-llvm
 #\
 #	-S -emit-llvm
@@ -40,7 +41,6 @@ LIBS=
 
 CXX=nvc++
 CC=nvc
-LAUNCHER  =
 
 #CXX=clang++
 #CC=clang

--- a/src/miniFE-sycl/Makefile
+++ b/src/miniFE-sycl/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean realclean run
 
-LAUNCHER  =
+LAUNCHER  ?=
 
 all:
 	$(MAKE) -C src

--- a/src/miniFE-sycl/Makefile
+++ b/src/miniFE-sycl/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all clean run
+.PHONY: all clean realclean run
+
+LAUNCHER  =
 
 all:
 	$(MAKE) -C src
@@ -6,7 +8,10 @@ all:
 clean:
 	$(MAKE) -C src clean
 
-# src/Makefile builds miniFE.x but doesn't define a `run:` target; invoke
-# the binary directly with a small default problem size.
+realclean:
+	$(MAKE) -C src realclean
+
+# Run from src/: miniFE writes its .yaml report into the working directory,
+# and only realclean removes it.
 run: all
-	cd src && ./main -nx 128 -ny 128 -nz 128
+	cd src && $(LAUNCHER) ./main -nx 128 -ny 128 -nz 128

--- a/src/miniFE-sycl/src/Makefile
+++ b/src/miniFE-sycl/src/Makefile
@@ -24,7 +24,6 @@ HIP_ARCH  = gfx908
 # reduce per-launch overhead of the many small CG kernels.
 ENQUEUE_FUNCTIONS = yes
 #GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
-LAUNCHER       =
 
 CPPFLAGS = -I. -I../utils -I../fem $(MINIFE_TYPES) $(MINIFE_MATRIX_TYPE) \
            -std=c++17 -Wall -fsycl --gcc-toolchain=$(GCC_TOOLCHAIN)


### PR DESCRIPTION
Supersedes #304, which fixed the missing AOMP entry point for miniFE-omp. Thanks @mhalk for reporting it.

miniFE-omp had no Makefile in the benchmark directory, so builds driven from there failed for all three toolchains, while miniFE-cuda, miniFE-hip, and miniFE-sycl already had wrappers. This adds `Makefile`, `Makefile.aomp`, and `Makefile.nvc` that delegate to `src` and forward `ARCH`, `SM`, and `EXTRA_CFLAGS`.

`LAUNCHER` was declared in every `src/Makefile*` across all four variants but never expanded, because the `run` recipe lives in `src/make_targets`, which invokes `./main` directly. It is now declared in the wrappers that own the `run` recipe, and the dead declarations are removed. A bare `LAUNCHER =` in the sub-makefile would also have silently overridden an environment-provided value if `make_targets` ever started using it.

Two further fixes make the forwarded variables meaningful rather than decorative:

- `miniFE-omp/src/Makefile.nvc` hardcoded `-gpu=cc70,fastmath` and ignored `SM`, even though `autohecbench.py` passes `SM=cc<version>` for nvc. It now uses `-gpu=$(SM),fastmath` with a `cc70` default.
- `miniFE-omp/src/Makefile` and `Makefile.nvc` overwrote `CFLAGS` without picking up `EXTRA_CFLAGS`, unlike `Makefile.aomp`. Both now prepend it.

Each wrapper also gains a `realclean` pass-through. That is the only target which removes the `miniFE-*.yaml` reports, and `run` deliberately executes from `src/` so those reports land where `realclean` can find them. The comment above `run` in the cuda, hip, and sycl wrappers was also inaccurate: it claimed `src/Makefile` has no `run` target and builds `miniFE.x`, but `make_targets` does define `run` and the binary is `main`.

## Test plan

- [x] `miniFE-omp` builds via the new `Makefile.aomp` with AOMP (ROCm 7.1.1, `amdclang++`, `ARCH=gfx90a`).
- [x] `LAUNCHER=...` reaches the binary from all six entry points (cuda, hip, sycl, and the three omp flavors).
- [x] `clean` and `realclean` delegate correctly in every variant.
- [ ] Runtime verification on an AMD GPU (no AMD device on the machine used here).