### PR TITLE
[mis] validate an input graph with more constraints

### DIFF
--- a/src/cc-cuda/main.cu
+++ b/src/cc-cuda/main.cu
@@ -385,6 +385,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   const int repeat = atoi(argv[2]);
 
   int* nodestatus = NULL;

--- a/src/cc-hip/main.cu
+++ b/src/cc-hip/main.cu
@@ -376,6 +376,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   const int repeat = atoi(argv[2]);
 
   int* nodestatus = NULL;

--- a/src/cc-sycl/main.cpp
+++ b/src/cc-sycl/main.cpp
@@ -467,6 +467,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   const int repeat = atoi(argv[2]);
 
   int* nodestatus = (int*) malloc (sizeof(int) * g.nodes);

--- a/src/gc-cuda/main.cu
+++ b/src/gc-cuda/main.cu
@@ -326,6 +326,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("input: %s\n", argv[1]);
   printf("nodes: %d\n", g.nodes);
   printf("edges: %d\n", g.edges);

--- a/src/gc-hip/main.cu
+++ b/src/gc-hip/main.cu
@@ -330,6 +330,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("input: %s\n", argv[1]);
   printf("nodes: %d\n", g.nodes);
   printf("edges: %d\n", g.edges);

--- a/src/gc-omp/main.cpp
+++ b/src/gc-omp/main.cpp
@@ -309,6 +309,7 @@ int main(int argc, char* argv[])
   const int repeat = atoi(argv[3]);
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("input: %s\n", argv[1]);
   printf("nodes: %d\n", g.nodes);
   printf("edges: %d\n", g.edges);

--- a/src/gc-sycl/main.cpp
+++ b/src/gc-sycl/main.cpp
@@ -345,6 +345,7 @@ int main(int argc, char *argv[]) {
 
   printf("input: %s\n", argv[1]);
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
 
   const int nodes = g.nodes;
   const int edges = g.edges;

--- a/src/mis-cuda/graph.h
+++ b/src/mis-cuda/graph.h
@@ -56,7 +56,8 @@ void freeECLgraph(ECLgraph &g)
 ECLgraph readECLgraph(const char* const fname)
 {
   ECLgraph g;
-  int cnt;
+  size_t cnt;
+  size_t nodes1;  // g.nodes + 1 computed in size_t to avoid overflowing int
   int error_status = 0;
   FILE* f = fopen(fname, "rb");
   if (f == NULL) {
@@ -78,9 +79,10 @@ ECLgraph readECLgraph(const char* const fname)
     exit(-1);
   }
 
-  g.nindex = (int*)malloc((g.nodes + 1) * sizeof(g.nindex[0]));
-  g.nlist = (int*)malloc(g.edges * sizeof(g.nlist[0]));
-  g.eweight = (int*)malloc(g.edges * sizeof(g.eweight[0]));
+  nodes1 = (size_t)g.nodes + 1;
+  g.nindex = (int*)malloc(nodes1 * sizeof(g.nindex[0]));
+  g.nlist = (int*)malloc((size_t)g.edges * sizeof(g.nlist[0]));
+  g.eweight = (int*)malloc((size_t)g.edges * sizeof(g.eweight[0]));
   if ((g.nindex == NULL) || (g.nlist == NULL) || (g.eweight == NULL)) {
     fprintf(stderr, "ERROR: memory allocation failed\n\n");
     error_status = 1;
@@ -88,8 +90,8 @@ ECLgraph readECLgraph(const char* const fname)
   }
 
   // check g.nindex
-  cnt = fread(g.nindex, sizeof(g.nindex[0]), g.nodes + 1, f);
-  if (cnt != g.nodes + 1) {
+  cnt = fread(g.nindex, sizeof(g.nindex[0]), nodes1, f);
+  if (cnt != nodes1) {
     fprintf(stderr, "ERROR: failed to read neighbor index list\n\n");
     error_status = 1;
     goto release;
@@ -113,14 +115,14 @@ ECLgraph readECLgraph(const char* const fname)
   }
 
   // check g.nlist
-  cnt = fread(g.nlist, sizeof(g.nlist[0]), g.edges, f);
-  if (cnt != g.edges) {
+  cnt = fread(g.nlist, sizeof(g.nlist[0]), (size_t)g.edges, f);
+  if (cnt != (size_t)g.edges) {
     fprintf(stderr, "ERROR: failed to read neighbor list\n\n");
     error_status = 1;
     goto release;
   }
   for (int v = 0; v < g.edges; v++) {
-    if (g.nlist[v] >= g.nodes) {
+    if ((g.nlist[v] < 0) || (g.nlist[v] >= g.nodes)) {
       fprintf(stderr, "ERROR: value in neighbor list must be a valide node index\n");
       error_status = 1;
       goto release;
@@ -128,25 +130,72 @@ ECLgraph readECLgraph(const char* const fname)
   }
 
   // check g.eweight (cnt = 0 is fine)
-  cnt = fread(g.eweight, sizeof(g.eweight[0]), g.edges, f);
+  cnt = fread(g.eweight, sizeof(g.eweight[0]), (size_t)g.edges, f);
   if (cnt == 0) {
     free(g.eweight);
     g.eweight = NULL;
   }
-  else if (cnt != g.edges) {
+  else if (cnt != (size_t)g.edges) {
     error_status = 1;
     fprintf(stderr, "ERROR: failed to read edge weights\n\n");
   }
 
-  fclose(f);
-
   release:
+  fclose(f);
   if (error_status) {
     freeECLgraph(g);
     exit(-1);
   }
 
   return g;
+}
+
+
+/* Algorithms such as ECL-MIS require a simple undirected graph: a node that is
+   its own neighbor, or an edge that is stored in only one of its two
+   directions, makes them spin forever waiting on a node that can never be
+   resolved.  Graphs that are legitimately directed (used by, e.g.,
+   floydwarshall2) must not be passed to this check. */
+
+void verifyUndirectedECLgraph(ECLgraph &g)
+{
+  for (int v = 0; v < g.nodes; v++) {
+    for (int i = g.nindex[v]; i < g.nindex[v + 1]; i++) {
+      if (g.nlist[i] == v) {
+        fprintf(stderr, "ERROR: neighbor list must not contain self loops\n");
+        freeECLgraph(g);
+        exit(-1);
+      }
+      if ((i > g.nindex[v]) && (g.nlist[i - 1] >= g.nlist[i])) {
+        fprintf(stderr, "ERROR: neighbor list of each node must be sorted in increasing order\n");
+        freeECLgraph(g);
+        exit(-1);
+      }
+    }
+  }
+
+  // the sorted neighbor lists allow the reverse edge to be located by bisection
+  for (int v = 0; v < g.nodes; v++) {
+    for (int i = g.nindex[v]; i < g.nindex[v + 1]; i++) {
+      const int u = g.nlist[i];
+      int lo = g.nindex[u];
+      int hi = g.nindex[u + 1] - 1;
+      int found = 0;
+      while (lo <= hi) {
+        const int mid = lo + (hi - lo) / 2;
+        if (g.nlist[mid] == v) {
+          found = 1;
+          break;
+        }
+        if (g.nlist[mid] < v) lo = mid + 1; else hi = mid - 1;
+      }
+      if (!found) {
+        fprintf(stderr, "ERROR: graph must be undirected, edge %d -> %d is not matched by %d -> %d\n", v, u, u, v);
+        freeECLgraph(g);
+        exit(-1);
+      }
+    }
+  }
 }
 
 #endif

--- a/src/mis-cuda/main.cu
+++ b/src/mis-cuda/main.cu
@@ -196,6 +196,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("configuration: %d nodes and %d edges (%s)\n", g.nodes, g.edges, argv[1]);
   printf("average degree: %.2f edges per node\n", 1.0 * g.edges / g.nodes);
 

--- a/src/mis-hip/main.cu
+++ b/src/mis-hip/main.cu
@@ -196,6 +196,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("configuration: %d nodes and %d edges (%s)\n", g.nodes, g.edges, argv[1]);
   printf("average degree: %.2f edges per node\n", 1.0 * g.edges / g.nodes);
 

--- a/src/mis-omp/main.cpp
+++ b/src/mis-omp/main.cpp
@@ -153,6 +153,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("configuration: %d nodes and %d edges (%s)\n", g.nodes, g.edges, argv[1]);
   printf("average degree: %.2f edges per node\n", 1.0 * g.edges / g.nodes);
 

--- a/src/mis-sycl/main.cpp
+++ b/src/mis-sycl/main.cpp
@@ -199,6 +199,7 @@ int main(int argc, char* argv[])
   }
 
   ECLgraph g = readECLgraph(argv[1]);
+  verifyUndirectedECLgraph(g);
   printf("configuration: %d nodes and %d edges (%s)\n", g.nodes, g.edges, argv[1]);
   printf("average degree: %.2f edges per node\n", 1.0 * g.edges / g.nodes);
 


### PR DESCRIPTION
Fixes #312.

## Problem

`readECLgraph` bounded the neighbor list only from above:

```c
if (g.nlist[v] >= g.nodes) { ... }
```

`g.nlist` is `int*` and `g.nodes` is `int`, so this is a signed comparison and a negative entry passes it. `findmins` then uses the value directly in `nstat[nlist[i]]`, where `nstat_d` is `nodes * sizeof(stattype)` bytes with `stattype` being `unsigned char`, so the read lands below the allocation. Reproduced with the reporter's PoC:

```
========= Invalid __global__ read of size 1 bytes
=========     at main.cu:77:findmins(int, const int *, const int *, volatile unsigned char *)
=========     Address 0xbddda60402 is out of bounds
=========     and is 687,864,830 bytes before the nearest allocation at 0xbe06a60000 of size 20 bytes
```

While fixing that I found two more crafted graphs that pass every existing check and make `findmins` loop forever instead of reading out of bounds. Both were still running when a 20 s timeout killed them, against 0.12 s for `internet.egr`:

* `nodes=2, nindex=[0,1,2], nlist=[0,1]` — each node is its own neighbor, so neither `nv > nstat[v]` nor `nv == nstat[v] && v > v` holds and the node can never beat itself.
* `nodes=2, nindex=[0,1,1], nlist=[1]` — the edge is stored in one direction only, so the neighbor never runs the `nstat[nlist[i]] = out` write that would clear the waiting node's low bit.

## Changes

* Reject negative neighbor list entries.
* Add `verifyUndirectedECLgraph`, which rejects self loops, unsorted or duplicated neighbor lists, and edges missing their reverse direction, and call it from `mis-cuda`, `mis-sycl`, `mis-hip`, and `mis-omp`.
* Compute allocation and read sizes in `size_t` so `g.nodes + 1` cannot overflow, and `fclose` the input on the error paths.

`verifyUndirectedECLgraph` is deliberately **not** part of `readECLgraph`. `src/mis-cuda/graph.h` is shared via `-I../mis-cuda` with `cc-*`, `gc-*`, and `floydwarshall2-*`, and `floydwarshall2`'s own input `CollegeMsg.egr` is a directed graph, so requiring symmetry in the reader would break it. The symmetry test uses bisection over each neighbor list, which is why sortedness is checked first.

## Testing

Verified on an NVIDIA Tesla M40 with CUDA 12.1, and with the oneAPI DPC++ SYCL compiler targeting the same GPU.

All four bad inputs are now rejected at load time by both `mis-cuda` and `mis-sycl`:

```
mis-memcheck-negative-index.txt  ERROR: value in neighbor list must be a valide node index
mis-memcheck.txt                 ERROR: neighbor index list always starts at value 0
selfloop.egr                     ERROR: neighbor list must not contain self loops
asym.egr                         ERROR: graph must be undirected, edge 0 -> 1 is not matched by 1 -> 0
```

`mis-cuda ./internet.egr 1` still passes under both `compute-sanitizer --tool=memcheck` and `--tool=initcheck` with `ERROR SUMMARY: 0 errors`.

No regressions in the benchmarks sharing the header: `cc-cuda` on `amazon0601.egr` reports `PASS`, `gc-cuda` colors the same graph, and `floydwarshall2-cuda` on the directed `CollegeMsg.egr` still reports `results match`. I also confirmed that `internet.egr`, `amazon0601.egr`, `soc-LiveJournal1.egr`, and `CollegeMsg.egr` are all free of self loops and have strictly sorted neighbor lists, so the new checks reject none of the in-tree inputs.

`mis-hip` and `mis-omp` were syntax checked only, as this machine has no AMD GPU and the OpenMP offload Makefile needs `icpx`.
