### PR TITLE
[mpc] fix out-of-bounds output write in MPCcompress (issue #317)

### DIFF
--- a/src/mpc-cuda/main.cu
+++ b/src/mpc-cuda/main.cu
@@ -383,7 +383,14 @@ int main(int argc, char *argv[])
 
   if (argc == 3) {
     dim = atoi(argv[2]);
-    outsize = insize + 1 + (insize + 63) / 64;
+    // Worst-case output size the compressor can emit: a header word, one bitmap
+    // word per 64 inputs, and up to one residual word per thread. Each of the
+    // ceil(insize/TPB) chunks launches TPB threads, so the residual region can
+    // grow to chunks*TPB words. Small inputs still transpose full 64-word
+    // bit-planes from the padded tail, so sizing residuals by insize alone
+    // under-allocates and lets MPCcompress write past d_out.
+    const int chunks = (insize + TPB - 1) / TPB;
+    outsize = 1 + (insize + 63) / 64 + chunks * TPB;
   } else {
     assert(((input[0] >> 8) & 0xffffff) == 0x43504d);
     dim = (input[0] & 31) + 1;

--- a/src/mpc-hip/main.cu
+++ b/src/mpc-hip/main.cu
@@ -389,7 +389,14 @@ int main(int argc, char *argv[])
 
   if (argc == 3) {
     dim = atoi(argv[2]);
-    outsize = insize + 1 + (insize + 63) / 64;
+    // Worst-case output size the compressor can emit: a header word, one bitmap
+    // word per 64 inputs, and up to one residual word per thread. Each of the
+    // ceil(insize/TPB) chunks launches TPB threads, so the residual region can
+    // grow to chunks*TPB words. Small inputs still transpose full 64-word
+    // bit-planes from the padded tail, so sizing residuals by insize alone
+    // under-allocates and lets MPCcompress write past d_out.
+    const int chunks = (insize + TPB - 1) / TPB;
+    outsize = 1 + (insize + 63) / 64 + chunks * TPB;
   } else {
     assert(((input[0] >> 8) & 0xffffff) == 0x43504d);
     dim = (input[0] & 31) + 1;

--- a/src/mpc-sycl/main.cpp
+++ b/src/mpc-sycl/main.cpp
@@ -423,7 +423,14 @@ int main(int argc, char *argv[])
 
   if (argc == 3) {
     dim = atoi(argv[2]);
-    outsize = insize + 1 + (insize + 63) / 64;
+    // Worst-case output size the compressor can emit: a header word, one bitmap
+    // word per 64 inputs, and up to one residual word per thread. Each of the
+    // ceil(insize/TPB) chunks launches TPB threads, so the residual region can
+    // grow to chunks*TPB words. Small inputs still transpose full 64-word
+    // bit-planes from the padded tail, so sizing residuals by insize alone
+    // under-allocates and lets MPCcompress write past d_out.
+    const int chunks = (insize + TPB - 1) / TPB;
+    outsize = 1 + (insize + 63) / 64 + chunks * TPB;
   } else {
     assert(((input[0] >> 8) & 0xffffff) == 0x43504d);
     dim = (input[0] & 31) + 1;


### PR DESCRIPTION
## Summary

Fixes #317 — a heap/global buffer overflow in the `MPCcompress` kernel reported with `compute-sanitizer` on a crafted small input.

The compressor sized the output buffer's residual region by the input word count (`insize`):

```c
outsize = insize + 1 + (insize + 63) / 64;
```

but `MPCcompress` can emit up to **one residual word per thread** across all launched threads. Small inputs still transpose full 64-word bit-planes from the padded tail, so a tiny input (e.g. one 8-byte word → 24-byte buffer) makes the kernel write past `d_out` at `compressed[start + tid]`, which the sanitizer flags as an invalid `__global__` write.

## Fix

Size the residual region to the worst case the kernel can emit — `ceil(insize/TPB)` chunks × `TPB` threads — plus the header and per-64 bitmap words:

```c
const int chunks = (insize + TPB - 1) / TPB;
outsize = 1 + (insize + 63) / 64 + chunks * TPB;
```

This is the "size `d_out` to the worst case the kernel can emit" option from the issue's suggested fix. The kernel is untouched, so there is no ABI change and no truncation of output.

Applied to the `mpc-cuda`, `mpc-hip`, and `mpc-sycl` variants.

## Notes

- No performance impact: the allocation is outside the timed region, and the device→host copy still uses the actual compressed length from the header (`output[0] >> 32`), so program output is unchanged.
- Only the compression path (`argc == 3`) is affected; decompression is unchanged.

## Test plan

- [x] Built the SYCL variant with the fix.
- [x] Ran a pathological 8-byte input (`0xAA…`, maximizing bit-plane residuals) — now completes cleanly.
- [ ] Rebuild `mpc-cuda` with `-lineinfo` and re-run `compute-sanitizer --tool=memcheck ./main ./mpc-memcheck.txt 1` to confirm no invalid writes (no CUDA toolchain on my machine).