### PR TITLE
Add OneMATH support as an alternative to oneMKL

### DIFF
--- a/src/blas-dot-sycl/Makefile
+++ b/src/blas-dot-sycl/Makefile
@@ -14,10 +14,14 @@ CUDA_ARCH ?= sm_70
 HIP       = no
 HIP_ARCH  ?= gfx908
 ONEMKL    = no
+ONEMATH   = no
 #GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
 
 # path to the install of the oneMKL interface
 ONEMKL_PATH   ?= /path/to/oneMKL
+
+# path to the install of the oneMath library
+ONEMATH_PATH  ?= /path/to/oneMath
 
 #===============================================================================
 # Program name & source code list
@@ -34,29 +38,42 @@ obj = $(source:.cpp=.o)
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -fsycl --gcc-toolchain=$(GCC_TOOLCHAIN) 
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -fsycl --gcc-toolchain=$(GCC_TOOLCHAIN)
 
 ifeq ($(VENDOR), AdaptiveCpp)
     CFLAGS_TMP := $(CFLAGS)
     CFLAGS = $(filter-out -fsycl, $(CFLAGS_TMP))
 endif
 
-# Linker Flags
-LDFLAGS = -ltbb
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH
+else
+  LDFLAGS = -ltbb
+endif
 
 ifeq ($(CUDA), yes)
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH) 
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
-ifeq ($(ONEMKL), yes)
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -I$(ONEMATH_PATH)/include
+else ifeq ($(ONEMKL), yes)
   CFLAGS += -I$(ONEMKL_PATH)/include
 else
   CFLAGS += -qmkl=parallel

--- a/src/blas-dot-sycl/main.cpp
+++ b/src/blas-dot-sycl/main.cpp
@@ -10,7 +10,14 @@
 #include <chrono>
 #include <cmath>
 #include <sycl/sycl.hpp>
+
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+#else
 #include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
 
 template <typename T>
 void dot (const size_t iNumElements, const int iNumIterations)
@@ -50,16 +57,21 @@ void dot (const size_t iNumElements, const int iNumIterations)
   auto start = std::chrono::steady_clock::now();
 
   for (int i = 0; i < iNumIterations; i++) {
-    oneapi::mkl::blas::dot(q, iNumElements, d_srcA, 1, d_srcB, 1, d_dst);
+    math_ns::blas::column_major::dot(q, iNumElements, d_srcA, 1, d_srcB, 1, d_dst);
   }
 
   q.wait();
   auto end = std::chrono::steady_clock::now();
   auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+#ifdef USE_ONEMATH
+  printf("Average oneMath::dot execution time %f (ms)\n", (time * 1e-6f) / iNumIterations);
+#else
   printf("Average oneMKL::dot execution time %f (ms)\n", (time * 1e-6f) / iNumIterations);
+#endif
   q.memcpy(&dst, d_dst, sizeof(T)).wait();
   printf("Host: %lf  Device: %lf\n", sum, double(dst));
-  printf("%s\n\n", (fabs(double(dst) - sum) < 1e-1) ? "PASS" : "FAIL");
+  const double tol = fmax(1e-6, 0.01 * fabs(sum));
+  printf("%s\n\n", (fabs(double(dst) - sum) < tol) ? "PASS" : "FAIL");
 
   sycl::free(d_dst, q);
   sycl::free(d_srcA, q);
@@ -82,10 +94,12 @@ int main(int argc, char **argv)
   dot<double>(iNumElements, iNumIterations);
   printf("\nFP32 Dot\n");
   dot<float>(iNumElements, iNumIterations);
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   printf("\nFP16 Dot\n");
   dot<sycl::half>(iNumElements, iNumIterations);
   printf("\nBF16 Dot\n");
   dot<sycl::ext::oneapi::bfloat16>(iNumElements, iNumIterations);
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/src/blas-gemm-sycl/Makefile
+++ b/src/blas-gemm-sycl/Makefile
@@ -19,6 +19,9 @@ ONEMKL    = no
 # path to the install of the oneMKL interface
 ONEMKL_PATH   ?= /path/to/oneMKL
 
+ONEMATH = no
+ONEMATH_PATH ?= /path/to/oneMath
+
 #===============================================================================
 # Program name & source code list
 #===============================================================================
@@ -45,17 +48,27 @@ ifeq ($(CUDA), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
-ifeq ($(ONEMKL), yes)
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH -I$(ONEMATH_PATH)/include
+else ifeq ($(ONEMKL), yes)
   CFLAGS += -I$(ONEMKL_PATH)/include
 else
   CFLAGS += -qmkl=parallel
@@ -91,3 +104,4 @@ clean:
 run: $(program)
 	$(LAUNCHER) ./$(program) 4096 768 2304 1000
 	$(LAUNCHER) ./$(program) 4096 4096 4096 100
+

--- a/src/blas-gemm-sycl/main.cpp
+++ b/src/blas-gemm-sycl/main.cpp
@@ -41,8 +41,15 @@
 
 // mkl/sycl includes
 #include <sycl/sycl.hpp>
-#include "oneapi/mkl/blas.hpp"
-#include "mkl.h"
+//#include "oneapi/mkl/blas.hpp"
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+#else
+#include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
+//#include "mkl.h"
 
 #include "utils.h"
 
@@ -85,7 +92,7 @@ void run_simple_gemm(sycl::queue &q, T *a, T *b, T *c, int M, int K, int N, T al
 // is performed and finally the results are post processed.
 //
 template <typename fp>
-void run_gemm_example(MKL_INT m, MKL_INT k, MKL_INT n, int repeat) {
+void run_gemm_example( int m, int k, int n, int repeat) {
 
   //
   // Initialize data for Gemm
@@ -93,34 +100,38 @@ void run_gemm_example(MKL_INT m, MKL_INT k, MKL_INT n, int repeat) {
   // C = alpha * op(A) * op(B)  + beta * C
   //
 
-  oneapi::mkl::transpose transA = oneapi::mkl::transpose::nontrans;
-  oneapi::mkl::transpose transB = oneapi::mkl::transpose::nontrans;
+  math_ns::transpose transA = math_ns::transpose::nontrans;
+  math_ns::transpose transB = math_ns::transpose::nontrans;
 
   // set scalar fp values
   fp alpha = fp(2.0);
   fp beta  = fp(0.5);
 
-  const size_t A_size = sizeof(fp) * m * k;
-  const size_t B_size = sizeof(fp) * k * n;
-  const size_t C_size = sizeof(fp) * m * n;
+  const size_t A_elems = (size_t)m * k;
+  const size_t B_elems = (size_t)k * n;
+  const size_t C_elems = (size_t)m * n;
 
-  // prepare matrix data
-  fp* a = (fp *)mkl_malloc(A_size, 64);
-  fp* b = (fp *)mkl_malloc(B_size, 64);
-  fp* c = (fp *)mkl_malloc(C_size, 64);
-  fp* r = (fp *)mkl_malloc(C_size, 64);
+  const size_t A_size = sizeof(fp) * A_elems;
+  const size_t B_size = sizeof(fp) * B_elems;
+  const size_t C_size = sizeof(fp) * C_elems;
 
-  srand(2);
-  rand_matrix(a, m, k);
-  rand_matrix(b, k, n);
-  rand_matrix(c, m, n);
-
-  // create execution queue and buffers of matrix data
 #ifdef USE_GPU
   sycl::queue q(sycl::gpu_selector_v, sycl::property::queue::in_order());
 #else
   sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());
 #endif
+
+  // prepare matrix data
+  fp* a = sycl::malloc_host<fp>(A_elems, q);
+  fp* b = sycl::malloc_host<fp>(B_elems, q);
+  fp* c = sycl::malloc_host<fp>(C_elems, q);
+  fp* r = sycl::malloc_host<fp>(C_elems, q);
+
+
+  srand(2);
+  rand_matrix(a, m, k);
+  rand_matrix(b, k, n);
+  rand_matrix(c, m, n);
 
   fp *da, *db, *dc, *dr;
   da = sycl::malloc_device<fp>(m*k, q);
@@ -129,24 +140,34 @@ void run_gemm_example(MKL_INT m, MKL_INT k, MKL_INT n, int repeat) {
   dr = sycl::malloc_device<fp>(m*n, q);
   q.memcpy(da, a, A_size);
   q.memcpy(db, b, B_size);
-  q.memcpy(dc, c, B_size);
-  q.memcpy(dr, c, B_size);
+  q.memcpy(dc, c, C_size);
+  q.memcpy(dr, c, C_size);
 
   std::cout << "Checking BLAS GEMM.. ";
   run_simple_gemm(q, da, db, dr, m, k, n, alpha, beta);
 
-  oneapi::mkl::blas::gemm(q, transA, transB,
+  math_ns::blas::column_major::gemm(q, transA, transB,
                           n, m, k, alpha, db, n, da, k, beta, dc, n);
   q.memcpy(c, dc, C_size).wait();
   q.memcpy(r, dr, C_size).wait();
-  int error = memcmp(c, r, C_size);
+
+  int error = 0;
+  for(size_t i = 0; i < C_elems; i++){
+    if( fabs(c[i] - r[i]) > 1e-1 ){
+      error++;
+      std::cout << c[i] << " " << r[i] << std::endl;
+    }
+  }
+
   std::cout << (error ? "FAIL" : "PASS") << std::endl;
+  if(error != 0)
+    std::cout << error  << " values missmatch" << std::endl;
 
   q.wait();
   auto start = std::chrono::steady_clock::now();
 
   for (int i = 0; i < repeat; i++) {
-    oneapi::mkl::blas::gemm(q, transA, transB, n, m, k,
+    math_ns::blas::column_major::gemm(q, transA, transB, n, m, k,
                             alpha, db, n, da, k, beta, dc, n);
   }
 
@@ -178,10 +199,10 @@ void run_gemm_example(MKL_INT m, MKL_INT k, MKL_INT n, int repeat) {
   sycl::free(dc, q);
   sycl::free(dr, q);
 
-  mkl_free(a);
-  mkl_free(b);
-  mkl_free(c);
-  mkl_free(r);
+  sycl::free(a, q);
+  sycl::free(b, q);
+  sycl::free(c, q);
+  sycl::free(r, q);
 }
 
 //

--- a/src/blas-gemmBatched-sycl/Makefile
+++ b/src/blas-gemmBatched-sycl/Makefile
@@ -19,6 +19,9 @@ ONEMKL    = no
 # path to the install of the oneMKL interface
 ONEMKL_PATH   ?= /path/to/oneMKL
 
+ONEMATH = no
+ONEMATH_PATH ?= /path/to/oneMath
+
 #===============================================================================
 # Program name & source code list
 #===============================================================================
@@ -46,17 +49,27 @@ ifeq ($(CUDA), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
-ifeq ($(ONEMKL), yes)
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH -I$(ONEMATH_PATH)/include
+else ifeq ($(ONEMKL), yes)
   CFLAGS += -I$(ONEMKL_PATH)/include
 else
   CFLAGS += -qmkl=parallel
@@ -91,3 +104,4 @@ clean:
 
 run: $(program)
 	$(LAUNCHER) ./$(program)
+

--- a/src/blas-gemmBatched-sycl/main.cpp
+++ b/src/blas-gemmBatched-sycl/main.cpp
@@ -5,7 +5,13 @@
 #include <cmath>
 #include <iostream>
 #include <sycl/sycl.hpp>
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+#else
 #include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
 #include "reference.h"
 
 using namespace std;
@@ -16,7 +22,7 @@ void gemmBatched(
   int upper,
   int num,
   int reps,
-  int verbose) try 
+  int verbose) try
 {
   if(verbose) cout << "initializing inputs" << endl;
   size_t matrices_size = upper * upper * num * sizeof(T);
@@ -102,11 +108,11 @@ void gemmBatched(
   q.memcpy(devCList, CList, num * sizeof(T *)).wait();
 
 
-  /* perform <num> <size x size> x <size x 1> multiplications 
+  /* perform <num> <size x size> x <size x 1> multiplications
      with distinct matrices
    */
   struct param_t {
-    oneapi::mkl::transpose transpose_info[2];
+    math_ns::transpose transpose_info[2];
     T value_info[2];
     std::int64_t size_info[3];
     std::int64_t ld_info[3];
@@ -114,8 +120,8 @@ void gemmBatched(
   };
 
   param_t *p = (param_t *)std::malloc(sizeof(param_t));
-  p->transpose_info[0] = oneapi::mkl::transpose::nontrans;
-  p->transpose_info[1] = oneapi::mkl::transpose::nontrans;
+  p->transpose_info[0] = math_ns::transpose::nontrans;
+  p->transpose_info[1] = math_ns::transpose::nontrans;
   p->value_info[0] = alpha;
   p->value_info[1] = beta;
   p->ld_info[0] = lda;
@@ -133,7 +139,7 @@ void gemmBatched(
     for(int rep = 0; rep <= reps; rep++){
       auto start = std::chrono::steady_clock::now();
 
-      oneapi::mkl::blas::column_major::gemm_batch(
+      math_ns::blas::column_major::gemm_batch(
         q, p->transpose_info, p->transpose_info + 1,
         p->size_info, p->size_info + 1,
         p->size_info + 2, p->value_info,
@@ -147,30 +153,34 @@ void gemmBatched(
       auto elapsed = time * 1e-3;
 
       if (rep != 0) sum += elapsed;
-      
+
       if(verbose)
-	cout << "size " << size << ": " << elapsed << " us; " 
-	     << elapsed / num << " us per operation" << endl;
+        cout << "size " << size << ": " << elapsed << " us; "
+             << elapsed / num << " us per operation" << endl;
     }
     cout << "size " << size << " average execution time: " << sum/reps << " us; "
-	 << sum / reps / num << " us per operation; "
+         << sum / reps / num << " us per operation; "
          << "floating-point operations per second: ";
     performance(m, n, k, 1e3 * (sum / reps / num));
 
-    // verify double precision operations 
+    // verify double precision operations
     if constexpr (std::is_same_v<T, double>) {
       q.memcpy(result, devResult, vectors_size).wait();
       gemmBatched_ref (num, upper, upper, 1, m, k, n, alpha, beta,
                        matrices, lda, vectors, ldb, result_ref, ldc);
 
+      int ok = 1;
       for (int i = 0; i < num; i++) {
       for (int j = 0; j < m; j++) {
         if (abs(result[i*upper+j] - result_ref[i*upper+j]) > 1e-6) {
           cout << "Mismatch at batch index " << i << ": " << result[i*upper+j] << "!="
                << result_ref[i*upper+j] << endl;
+          ok = 0;
           break;
         }
       }}
+
+      printf("%s\n", ok ? "PASS" : "FAIL");
     }
   }
 
@@ -204,7 +214,7 @@ int main(int argc, char **argv) {
   int num = 25000;  // batch size
   int reps = 10;
   int verbose = 0;
-  
+
   while((status = getopt(argc, argv, "l:u:n:r:v")) != -1){
     switch(status){
     case 'l':
@@ -237,6 +247,6 @@ int main(int argc, char **argv) {
   gemmBatched<float>(lower, upper, num, reps, verbose);
   cout << ">>>>>>>>>>>>>>> Double precision gemmBatched >>>>>>>>>>>>>>> " << endl;
   gemmBatched<double>(lower, upper, num, reps, verbose);
-      
+
   return 0;
 }

--- a/src/blas-gemmEx-sycl/Makefile
+++ b/src/blas-gemmEx-sycl/Makefile
@@ -14,6 +14,8 @@ CUDA_ARCH ?= sm_70
 HIP       = no
 HIP_ARCH  ?= gfx908
 ONEMKL    = no
+ONEMATH      = no
+ONEMATH_PATH ?= /path/to/oneMath
 #GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
 
 # path to the install of the oneMKL interface
@@ -46,17 +48,27 @@ ifeq ($(CUDA), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
-ifeq ($(ONEMKL), yes)
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -I$(ONEMATH_PATH)/include -DUSE_ONEMATH
+else ifeq ($(ONEMKL), yes)  
   CFLAGS += -I$(ONEMKL_PATH)/include
 else
   CFLAGS += -qmkl=parallel

--- a/src/blas-gemmEx-sycl/main.cpp
+++ b/src/blas-gemmEx-sycl/main.cpp
@@ -1,10 +1,20 @@
 #include <stdio.h>
 #include <chrono>
 #include <sycl/sycl.hpp>
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+enum class compute_mode_t { standard, float_to_bf16, float_to_tf32 };
+#else
 #include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+using compute_mode_t = math_ns::blas::compute_mode;
+#endif
 #include "utils.h"
 
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
 using sycl::ext::oneapi::bfloat16;
+#endif
 
 template <typename T, typename S>
 void allocate_memory(sycl::queue &q, int m, int n, int k, T **A, T **B, S **C) {
@@ -23,24 +33,36 @@ void free_memory(sycl::queue &q, T *A, T *B, S *C) {
 template <typename Ta, typename Tc, typename Ts>
 bool mkl_gemm_ex(
     sycl::queue &q,
-    oneapi::mkl::transpose transA,
-    oneapi::mkl::transpose transB,
+    math_ns::transpose transA,
+    math_ns::transpose transB,
     int m, int n, int k,
     Ta *A, Ta *B, Tc *C,
     int lda, int ldb, int ldc,
-    Ts alpha, Ts beta,
-    oneapi::mkl::blas::compute_mode mode =
-      oneapi::mkl::blas::compute_mode::standard)
+    const Ts alpha, const Ts beta,
+    compute_mode_t mode =
+      compute_mode_t::standard)
 {
   sycl::event status;
   try {
-    status = oneapi::mkl::blas::column_major::gemm(
+#ifdef USE_ONEMATH
+    // no compute mode equivalent in oneMath yet
+    (void)mode;
+    status = math_ns::blas::column_major::gemm(
       q,
       transA, transB,
       m, n, k,
       alpha, A, lda,
       B, ldb, beta,
       C, ldc);
+#else
+    status = math_ns::blas::column_major::gemm(
+      q,
+      transA, transB,
+      m, n, k,
+      alpha, A, lda,
+      B, ldb, beta,
+      C, ldc, mode);
+#endif
   } catch(sycl::exception const& e) {
     std::cout << "\t\tCaught synchronous SYCL exception during GEMM:\n"
               << e.what() << std::endl;
@@ -55,16 +77,16 @@ void test_gemm(sycl::queue &q,
                const int m, const int n, const int k,
                Ta *A, Ta *B, Tc *C,
                const Ts alpha, const Ts beta, int iteration,
-               oneapi::mkl::blas::compute_mode mode =
-                 oneapi::mkl::blas::compute_mode::standard)
+               compute_mode_t mode =
+                 compute_mode_t::standard)
 {
   double total_time = 0;
 
   for (int i = 0; i < iteration; ++i) {
     auto start = std::chrono::steady_clock::now();
     bool success = mkl_gemm_ex(q,
-                               oneapi::mkl::transpose::nontrans,
-                               oneapi::mkl::transpose::nontrans,
+                               math_ns::transpose::nontrans,
+                               math_ns::transpose::nontrans,
                                n, // number of rows of matrix A and C
                                m, // number of columns of matrix B and C
                                k, // number of columns of A and rows of B
@@ -115,48 +137,61 @@ int main(int argc, char* argv[]) {
                            .convert<sycl::half, sycl::rounding_mode::rte>()[0],
              h_beta = sycl::vec<float, 1>{0.f}
                           .convert<sycl::half, sycl::rounding_mode::rte>()[0];
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   const float bf_alpha = 1.f, bf_beta = 0.f;
   const int32_t i_alpha = 1, i_beta = 0;
+#endif
 
   double *dA, *dB, *dC;
   float *fA, *fB, *fC;
   sycl::half *hA, *hB, *hC;
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   bfloat16 *bfA, *bfB, *bfC;
   int8_t *iA, *iB; int32_t *iC;
+#endif
 
   allocate_memory(q, m, n, k, &dA, &dB, &dC);
   allocate_memory(q, m, n, k, &fA, &fB, &fC);
   allocate_memory(q, m, n, k, &hA, &hB, &hC);
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   allocate_memory(q, m, n, k, &bfA, &bfB, &bfC);
   allocate_memory(q, m, n, k, &iA, &iB, &iC);
+#endif
 
   for (int i = 0; i < m * k; ++i) {
     dA[i] = double(i % 255 - 127) / 127;
     fA[i] = float(i % 255 - 127) / 127;
     hA[i] = sycl::vec<float, 1>{fA[i]}
                 .convert<sycl::half, sycl::rounding_mode::rte>()[0];
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
     bfA[i] = bfloat16(fA[i]);
     iA[i] = float2int8(fA[i], 127);
+#endif
   }
   for (int i = 0; i < k * n; ++i) {
     dB[i] = double(i % 255 - 127) / 127;
     fB[i] = float(i % 255 - 127) / 127;
     hB[i] = sycl::vec<float, 1>{fB[i]}
                 .convert<sycl::half, sycl::rounding_mode::rte>()[0];
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
     bfB[i] = bfloat16(fB[i]);
     iB[i] = float2int8(fB[i], 127);
+#endif
   }
+
 
   printf(">>>>>>>>>>>>>>>>> test fp64 >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, dA, dB, dC, d_alpha, d_beta, iteration);
 
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   printf(">>>>>>>>>>>>>>>>> test fp32 (compute mode bf16) >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, fA, fB, fC, f_alpha, f_beta, iteration,
-            oneapi::mkl::blas::compute_mode::float_to_bf16);
+            compute_mode_t::float_to_bf16);
 
   printf(">>>>>>>>>>>>>>>>> test fp32 (compute mode tf32) >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, fA, fB, fC, f_alpha, f_beta, iteration,
-            oneapi::mkl::blas::compute_mode::float_to_tf32);
+            compute_mode_t::float_to_tf32);
+#endif
 
   printf(">>>>>>>>>>>>>>>>> test fp32 (compute mode fp32) >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, fA, fB, fC, f_alpha, f_beta, iteration);
@@ -164,11 +199,15 @@ int main(int argc, char* argv[]) {
   printf(">>>>>>>>>>>>>>>>> test fp16 >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, hA, hB, hC, h_alpha, h_beta, iteration);
 
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   printf(">>>>>>>>>>>>>>>>> test bfloat16 >>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, bfA, bfB, bfC, bf_alpha, bf_beta, iteration);
 
   printf(">>>>>>>>>>>>>>>>> test int8 >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, iA, iB, iC, i_alpha, i_beta, iteration);
+#endif
+
+
 
   printf(">>>>>>>>>>>>>>>>> compare result >>>>>>>>>>>>>>>>>\n");
   printf("fp64: ");
@@ -183,6 +222,7 @@ int main(int argc, char* argv[]) {
   for (int i = 0; i < 10; ++i)
     printf("%.5f%c", float(hC[i]), " \n"[i==9]);
 
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   printf("bf16: ");
   for (int i = 0; i < 10; ++i)
     printf("%.5f%c", float(bfC[i]), " \n"[i==9]);
@@ -190,11 +230,14 @@ int main(int argc, char* argv[]) {
   printf("int8: ");
   for (int i = 0; i < 10; ++i)
     printf("%.5f%c", float(iC[i])/127/127, " \n"[i==9]);
+#endif
 
   free_memory(q, dA, dB, dC);
   free_memory(q, fA, fB, fC);
   free_memory(q, hA, hB, hC);
+#if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   free_memory(q, bfA, bfB, bfC);
   free_memory(q, iA, iB, iC);
+#endif
   return 0;
 }

--- a/src/blas-gemmEx-sycl/main.cpp
+++ b/src/blas-gemmEx-sycl/main.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <chrono>
+#include <cmath>
 #include <sycl/sycl.hpp>
 #ifdef USE_ONEMATH
 #include <oneapi/math.hpp>
@@ -28,6 +29,37 @@ void free_memory(sycl::queue &q, T *A, T *B, S *C) {
   sycl::free(A, q);
   sycl::free(B, q);
   sycl::free(C, q);
+}
+
+void compute_reference(const double *A, const double *B, double *ref,
+                        int rows, int n, int k)
+{
+  for (int i = 0; i < rows; ++i) {
+    for (int j = 0; j < n; ++j) {
+      double sum = 0.0;
+      for (int p = 0; p < k; ++p)
+        sum += A[i * k + p] * B[p * n + j];
+      ref[i * n + j] = sum;
+    }
+  }
+}
+
+template <typename Tc>
+bool verify_gemm(const char *name, const double *ref, const Tc *C,
+                  int rows, int n, double tol, double scale = 1.0)
+{
+  double max_err = 0.0;
+  for (int i = 0; i < rows; ++i) {
+    for (int j = 0; j < n; ++j) {
+      double val = double(C[i * n + j]) * scale;
+      double err = fabs(val - ref[i * n + j]);
+      if (err > max_err) max_err = err;
+    }
+  }
+  bool ok = max_err <= tol;
+  printf("%-32s %s (max abs error = %.6f, tol = %.6f)\n",
+         name, ok ? "PASS" : "FAIL", max_err, tol);
+  return ok;
 }
 
 template <typename Ta, typename Tc, typename Ts>
@@ -179,34 +211,51 @@ int main(int argc, char* argv[]) {
 #endif
   }
 
+  const int verify_rows = (m < 8) ? m : 8;
+  double *ref = (double*) malloc(verify_rows * n * sizeof(double));
+  if (ref == nullptr) {
+    printf("reference buffer allocation failed\n");
+    return 1;
+  }
+  compute_reference(dA, dB, ref, verify_rows, n, k);
+  const double base_tol = double(k);
+
 
   printf(">>>>>>>>>>>>>>>>> test fp64 >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, dA, dB, dC, d_alpha, d_beta, iteration);
+  verify_gemm("fp64", ref, dC, verify_rows, n, 1e-6 * base_tol);
 
 #if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   printf(">>>>>>>>>>>>>>>>> test fp32 (compute mode bf16) >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, fA, fB, fC, f_alpha, f_beta, iteration,
             compute_mode_t::float_to_bf16);
+  verify_gemm("fp32 (bf16 compute mode)", ref, fC, verify_rows, n, 5e-2 * base_tol);
 
   printf(">>>>>>>>>>>>>>>>> test fp32 (compute mode tf32) >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, fA, fB, fC, f_alpha, f_beta, iteration,
             compute_mode_t::float_to_tf32);
+  verify_gemm("fp32 (tf32 compute mode)", ref, fC, verify_rows, n, 1e-2 * base_tol);
 #endif
 
   printf(">>>>>>>>>>>>>>>>> test fp32 (compute mode fp32) >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, fA, fB, fC, f_alpha, f_beta, iteration);
+  verify_gemm("fp32", ref, fC, verify_rows, n, 1e-3 * base_tol);
 
   printf(">>>>>>>>>>>>>>>>> test fp16 >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, hA, hB, hC, h_alpha, h_beta, iteration);
+  verify_gemm("fp16", ref, hC, verify_rows, n, 5e-2 * base_tol);
 
 #if defined(__SYCL_COMPILER_VERSION) && !defined(USE_ONEMATH)
   printf(">>>>>>>>>>>>>>>>> test bfloat16 >>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, bfA, bfB, bfC, bf_alpha, bf_beta, iteration);
+  verify_gemm("bf16", ref, bfC, verify_rows, n, 8e-2 * base_tol);
 
   printf(">>>>>>>>>>>>>>>>> test int8 >>>>>>>>>>>>>>>>>\n");
   test_gemm(q, m, n, k, iA, iB, iC, i_alpha, i_beta, iteration);
+  verify_gemm("int8", ref, iC, verify_rows, n, 5e-1 * base_tol, 1.0 / (127.0 * 127.0));
 #endif
 
+  free(ref);
 
 
   printf(">>>>>>>>>>>>>>>>> compare result >>>>>>>>>>>>>>>>>\n");

--- a/src/blas-gemmStridedBatched-sycl/Makefile
+++ b/src/blas-gemmStridedBatched-sycl/Makefile
@@ -19,6 +19,9 @@ ONEMKL    = no
 # path to the install of the oneMKL interface
 ONEMKL_PATH   ?= /path/to/oneMKL
 
+ONEMATH = no
+ONEMATH_PATH ?= /path/to/oneMath
+
 #===============================================================================
 # Program name & source code list
 #===============================================================================
@@ -46,17 +49,27 @@ ifeq ($(CUDA), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
-ifeq ($(ONEMKL), yes)
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH -I$(ONEMATH_PATH)/include
+else ifeq ($(ONEMKL), yes)
   CFLAGS += -I$(ONEMKL_PATH)/include
 else
   CFLAGS += -qmkl=parallel
@@ -91,3 +104,4 @@ clean:
 
 run: $(program)
 	$(LAUNCHER) ./$(program)
+

--- a/src/blas-gemmStridedBatched-sycl/main.cpp
+++ b/src/blas-gemmStridedBatched-sycl/main.cpp
@@ -5,7 +5,13 @@
 #include <cmath>
 #include <iostream>
 #include <sycl/sycl.hpp>
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+#else
 #include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
 #include "reference.h"
 
 using namespace std;
@@ -16,7 +22,7 @@ void gemmBatched(
   int upper,
   int num,
   int reps,
-  int verbose) try 
+  int verbose) try
 {
   if(verbose) cout << "initializing inputs" << endl;
   size_t matrices_size = upper * upper * num * sizeof(T);
@@ -71,11 +77,11 @@ void gemmBatched(
 
   const T alpha = 1.0f, beta = 0.0f;
 
-  /* perform <num> <size x size> x <size x 1> multiplications 
+  /* perform <num> <size x size> x <size x 1> multiplications
      with distinct matrices
    */
   struct param_t {
-    oneapi::mkl::transpose transpose_info[2];
+    math_ns::transpose transpose_info[2];
     T value_info[2];
     std::int64_t size_info[3];
     std::int64_t ld_info[3];
@@ -83,8 +89,8 @@ void gemmBatched(
   };
 
   param_t *p = (param_t *)std::malloc(sizeof(param_t));
-  p->transpose_info[0] = oneapi::mkl::transpose::nontrans;
-  p->transpose_info[1] = oneapi::mkl::transpose::nontrans;
+  p->transpose_info[0] = math_ns::transpose::nontrans;
+  p->transpose_info[1] = math_ns::transpose::nontrans;
   p->value_info[0] = alpha;
   p->value_info[1] = beta;
   p->ld_info[0] = lda;
@@ -104,7 +110,7 @@ void gemmBatched(
     for(int rep = 0; rep <= reps; rep++){
       auto start = std::chrono::steady_clock::now();
 
-      oneapi::mkl::blas::column_major::gemm_batch(
+      math_ns::blas::column_major::gemm_batch(
         q, p->transpose_info[0], p->transpose_info[1],
         p->size_info[0], p->size_info[1], p->size_info[2],
         p->value_info[0],
@@ -119,30 +125,35 @@ void gemmBatched(
       auto elapsed = time * 1e-3;
 
       if (rep != 0) sum += elapsed;
-      
+
       if(verbose)
-	cout << "size " << size << ": " << elapsed << " us; " 
-	     << elapsed / num << " us per operation" << endl;
+        cout << "size " << size << ": " << elapsed << " us; "
+             << elapsed / num << " us per operation" << endl;
     }
     cout << "size " << size << " average execution time: " << sum/reps << " us; "
-	 << sum / reps / num << " us per operation; "
+         << sum / reps / num << " us per operation; "
          << "floating-point operations per second: ";
     performance(m, n, k, 1e3 * (sum / reps / num));
 
-    // verify double precision operations 
+    // verify double precision operations
     if constexpr (std::is_same_v<T, double>) {
       q.memcpy(result, devResult, vectors_size).wait();
       gemmBatched_ref (num, upper, upper, 1, m, k, n, alpha, beta,
                        matrices, lda, vectors, ldb, result_ref, ldc);
 
+
+      int ok = 1;
       for (int i = 0; i < num; i++) {
       for (int j = 0; j < m; j++) {
         if (abs(result[i*upper+j] - result_ref[i*upper+j]) > 1e-6) {
           cout << "Mismatch at batch index " << i << ": " << result[i*upper+j] << "!="
                << result_ref[i*upper+j] << endl;
+          ok = 0;
           break;
         }
       }}
+
+      printf("%s\n", ok ? "PASS" : "FAIL");
     }
   }
 
@@ -170,7 +181,7 @@ int main(int argc, char **argv) {
   int num = 25000;  // batch size
   int reps = 10;
   int verbose = 0;
-  
+
   while((status = getopt(argc, argv, "l:u:n:r:v")) != -1){
     switch(status){
     case 'l':
@@ -203,6 +214,6 @@ int main(int argc, char **argv) {
   gemmBatched<float>(lower, upper, num, reps, verbose);
   cout << ">>>>>>>>>>>>>>> Double precision gemmBatched >>>>>>>>>>>>>>> " << endl;
   gemmBatched<double>(lower, upper, num, reps, verbose);
-      
+
   return 0;
 }

--- a/src/dropout-sycl/Makefile
+++ b/src/dropout-sycl/Makefile
@@ -13,7 +13,13 @@ CUDA      = no
 CUDA_ARCH ?= sm_70
 HIP       = no
 HIP_ARCH  ?= gfx908
+ONEMKL    = no
+ONEMATH      = no
+ONEMATH_PATH ?= /path/to/oneMath
 #GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
+
+# path to the install of the oneMKL interface
+ONEMKL_PATH   = /path/to/oneMKL
 
 #===============================================================================
 # Program name & source code list
@@ -38,7 +44,7 @@ ifeq ($(VENDOR), AdaptiveCpp)
 endif
 
 # Linker Flags
-LDFLAGS = 
+LDFLAGS =
 
 ifeq ($(CUDA), yes)
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
@@ -47,7 +53,15 @@ endif
 
 ifeq ($(HIP), yes)
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH) 
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+endif
+
+ifeq ($(ONEMKL), yes)
+  CFLAGS += -I$(ONEMKL_PATH)/include -I$(ONEMKL_PATH)/include/oneapi
+else ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH -I$(ONEMATH_PATH)/include -I$(ONEMATH_PATH)/include/oneapi
+else
+  CFLAGS += -qmkl=parallel
 endif
 
 # Debug Flags

--- a/src/dropout-sycl/main.cpp
+++ b/src/dropout-sycl/main.cpp
@@ -1,11 +1,18 @@
 #include <cstdio>
 #include <chrono>
 #include <utility> // std::pair
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+#include <oneapi/math/rng/device.hpp>
+namespace math_ns = oneapi::math;
+#else
 #include <oneapi/mkl.hpp>
 #include <oneapi/mkl/rng/device.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
 #include <sycl/sycl.hpp>
 
-// philox generates 128 bits of randomness at a time. 
+// philox generates 128 bits of randomness at a time.
 // Kernel uses this explicitly by putting suitably transformed result into float4
 // for all members of float4 to be consumed UNROLL has to be 4. Don't change!
 const int UNROLL = 4;
@@ -23,7 +30,7 @@ void fused_dropout_kernel(const scalar_t *__restrict__ a,
   IndexType blockDim = item.get_local_range(0);
   IndexType gridDim = item.get_group_range(0);
 
-  oneapi::mkl::rng::device::philox4x32x10<4> engine (
+  math_ns::rng::device::philox4x32x10<4> engine (
       seeds.first, {seeds.second, idx * 4});
 
   IndexType rounded_size = ((totalElements - 1) / (blockDim * gridDim * UNROLL) + 1) *
@@ -32,8 +39,8 @@ void fused_dropout_kernel(const scalar_t *__restrict__ a,
   for (IndexType linearIndex = idx; linearIndex < rounded_size;
        linearIndex += gridDim * blockDim * UNROLL) {
 
-    oneapi::mkl::rng::device::uniform<float> distr;
-    sycl::float4 rand = oneapi::mkl::rng::device::generate(distr, engine);
+    math_ns::rng::device::uniform<float> distr;
+    sycl::float4 rand = math_ns::rng::device::generate(distr, engine);
 
     scalar_t src[UNROLL];
     rand.x() = rand.x() < p;
@@ -88,7 +95,7 @@ void fused_dropout_kernel_vec(const scalar_t *__restrict__ a,
   IndexType blockDim = item.get_local_range(0);
   IndexType gridDim = item.get_group_range(0);
 
-  oneapi::mkl::rng::device::philox4x32x10<4> engine (
+  math_ns::rng::device::philox4x32x10<4> engine (
       seeds.first, {seeds.second, idx * 4});
 
   // Note: Vectorized loads means we'll stride each thread by an additional VEC factor, as we'll load VEC elements at a time
@@ -100,8 +107,8 @@ void fused_dropout_kernel_vec(const scalar_t *__restrict__ a,
 
     sycl::float4 rand;
     if ((VEC == 4) || (gridxvec_loop_state == 0)) {
-      oneapi::mkl::rng::device::uniform<float> distr;
-      rand = oneapi::mkl::rng::device::generate(distr, engine);
+      math_ns::rng::device::uniform<float> distr;
+      rand = math_ns::rng::device::generate(distr, engine);
     } else {
       // sets up the last two values we generated last iteration to be used this iteration.
       rand.x() = rand.z();
@@ -158,8 +165,8 @@ int main(int argc, char *argv[]) {
   int64_t ret_size = self_size;
   int64_t mask_size = nelem * sizeof(uint8_t);
 
-  float *self_info = (float*) malloc (self_size); 
-  float *ret_info = (float*) malloc (ret_size); 
+  float *self_info = (float*) malloc (self_size);
+  float *ret_info = (float*) malloc (ret_size);
   uint8_t *mask_info = (uint8_t*) malloc (mask_size);
 
   for (int64_t i = 0; i < nelem; i++) {
@@ -194,7 +201,7 @@ int main(int argc, char *argv[]) {
   auto end = std::chrono::steady_clock::now();
   auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
   printf("Total kernel execution time (VEC1) %lf (s)\n", time * 1e-9f);
- 
+
   start = std::chrono::steady_clock::now();
   for (int p = 1; p <= repeat; p++) {
     float pa = (float)p / repeat;
@@ -230,9 +237,9 @@ int main(int argc, char *argv[]) {
   sycl::free(d_self_info, q);
   sycl::free(d_ret_info, q);
   sycl::free(d_mask_info, q);
-  free(self_info); 
-  free(ret_info); 
-  free(mask_info); 
+  free(self_info);
+  free(ret_info);
+  free(mask_info);
 
   return 0;
 }

--- a/src/norm2-sycl/Makefile
+++ b/src/norm2-sycl/Makefile
@@ -13,10 +13,13 @@ CUDA      = no
 CUDA_ARCH ?= sm_70
 HIP       = no
 HIP_ARCH  ?= gfx908
+ONEMKL    = no
+ONEMATH      = no
+ONEMATH_PATH ?= /path/to/oneMath
 #GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
 
-# path to oneMKL with cublas support
-ONEMKL    = /path/to/oneMKL
+# path to the install of the oneMKL interface
+ONEMKL_PATH   = /path/to/oneMKL
 
 #===============================================================================
 # Program name & source code list
@@ -33,13 +36,18 @@ obj = $(source:.cpp=.o)
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -fsycl -I$(ONEMKL)/include \
-          --gcc-toolchain=$(GCC_TOOLCHAIN) \
-          -I${MKLROOT} -DMKL_ILP64 -qmkl=parallel
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -fsycl -I$(ONEMKL_PATH)/include \
+          --gcc-toolchain=$(GCC_TOOLCHAIN)
 
 ifeq ($(VENDOR), AdaptiveCpp)
     CFLAGS_TMP := $(CFLAGS)
     CFLAGS = $(filter-out -fsycl, $(CFLAGS_TMP))
+endif
+
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH -I$(ONEMATH_PATH)/include
+else
+  CFLAGS += -I${MKLROOT} -DMKL_ILP64 -qmkl=parallel
 endif
 
 # Linker Flags
@@ -48,11 +56,21 @@ LDFLAGS =
 ifeq ($(CUDA), yes)
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS += -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS += -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH) 
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS += -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS += -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS += -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
 # Debug Flags

--- a/src/norm2-sycl/main.cpp
+++ b/src/norm2-sycl/main.cpp
@@ -4,7 +4,13 @@
 #include <algorithm>
 #include <chrono>
 #include <vector>
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+#else
 #include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
 #include <sycl/sycl.hpp>
 
 int main(int argc, char *argv[]) {
@@ -74,7 +80,7 @@ int main(int argc, char *argv[]) {
 
     try {
       for (j = 0; j < repeat; j++) {
-        status[j] = oneapi::mkl::blas::column_major::nrm2(q, n, d_a, 1, d_result+j);
+        status[j] = math_ns::blas::column_major::nrm2(q, n, d_a, 1, d_result+j);
         q.memcpy(h_result + j, d_result + j, sizeof(float), status[j]);
       }
     } catch(sycl::exception const& e) {
@@ -92,7 +98,8 @@ int main(int argc, char *argv[]) {
 
     // snrm2 results match across all iterations
     for (j = 0; j < repeat; j++)
-      if (fabsf((float)gold - h_result[j]) > 1e-1f) {
+      if (fabsf((float)gold - h_result[j]) >
+          fmaxf(1e-6f, 0.01f * fabsf((float)gold))) {
         printf("FAIL at iteration %d: gold=%f actual=%f for %d elements\n",
                j, (float)gold, h_result[j], i);
         ok = false;

--- a/src/rayleighBenardConvection-sycl/Makefile
+++ b/src/rayleighBenardConvection-sycl/Makefile
@@ -19,6 +19,9 @@ ONEMKL    = no
 # path to the install of the oneMKL interface
 ONEMKL_PATH   ?= /path/to/oneMKL
 
+ONEMATH = no
+ONEMATH_PATH ?= /path/to/oneMath
+
 #===============================================================================
 # Program name & source code list
 #===============================================================================
@@ -45,17 +48,27 @@ ifeq ($(CUDA), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
             -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
-endif
-
-ifeq ($(HIP), yes)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_cublas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_cublas
+  endif
+else ifeq ($(HIP), yes)
   ONEMKL = yes
   CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
-	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
-  LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+            -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+  ifeq ($(ONEMATH), yes)
+    LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath -lonemath_blas_rocblas
+  else
+    LDFLAGS = -L$(ONEMKL_PATH)/lib -lonemkl -lonemkl_blas_rocblas
+  endif
+else ifeq ($(ONEMATH), yes)
+  LDFLAGS = -L$(ONEMATH_PATH)/lib -lonemath
 endif
 
-ifeq ($(ONEMKL), yes)
+ifeq ($(ONEMATH), yes)
+  CFLAGS += -DUSE_ONEMATH -I$(ONEMATH_PATH)/include
+else ifeq ($(ONEMKL), yes)
   CFLAGS += -I$(ONEMKL_PATH)/include
 else
   CFLAGS += -qmkl=parallel

--- a/src/rayleighBenardConvection-sycl/main.cpp
+++ b/src/rayleighBenardConvection-sycl/main.cpp
@@ -14,7 +14,13 @@
 #include <string.h>
 #include <chrono>
 #include <sycl/sycl.hpp>
+#ifdef USE_ONEMATH
+#include <oneapi/math.hpp>
+namespace math_ns = oneapi::math;
+#else
 #include <oneapi/mkl.hpp>
+namespace math_ns = oneapi::mkl;
+#endif
 
 // Parameters.  These may change from run-to-run
 #define M         (500)         // vertical dimension of the temperature array
@@ -158,19 +164,19 @@ float NusseltCompute(sycl::queue &q, float *T, float *nutop, float *ztop,
   // with all 0s along the bottom.
 
   // Copy the last three rows of T into the first three rows of nutop
-  oneapi::mkl::blas::column_major::copy(q, N, (T + (M - 5) * N), 1, (nutop), 1);
-  oneapi::mkl::blas::column_major::copy(q, N, (T + (M - 4) * N), 1, (nutop + (N)), 1);
-  oneapi::mkl::blas::column_major::copy(q, N, (T + (M - 3) * N), 1, (nutop + (2 * N)), 1);
+  math_ns::blas::column_major::copy(q, N, (T + (M - 5) * N), 1, (nutop), 1);
+  math_ns::blas::column_major::copy(q, N, (T + (M - 4) * N), 1, (nutop + (N)), 1);
+  math_ns::blas::column_major::copy(q, N, (T + (M - 3) * N), 1, (nutop + (2 * N)), 1);
 
   float alpha = 0.f;
 
   // Set the last row of nutop = 0.
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, (nutop + (3 * N)), 1);
+  math_ns::blas::column_major::scal(q, N, alpha, (nutop + (3 * N)), 1);
 
   // nutop += -( 1 - ztop)
   // => nutop += ztop; nutop -= 1
   alpha = 1.f;
-  oneapi::mkl::blas::column_major::axpy(q, 4 * N, alpha, ztop, 1, nutop, 1);
+  math_ns::blas::column_major::axpy(q, 4 * N, alpha, ztop, 1, nutop, 1);
 
   sycl::range<2> gws (1, (floorf(N / 256.f) + 1) * 256);
   sycl::range<2> lws (1, 256);
@@ -197,19 +203,19 @@ float NusseltCompute(sycl::queue &q, float *T, float *nutop, float *ztop,
   // accumulate in the 0th row
   // scale the 0th row by -(2/3)
   alpha = -(2.f/3.f);
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, nutop, 1);
+  math_ns::blas::column_major::scal(q, N, alpha, nutop, 1);
   // Add 3*row1
   alpha = 3.f;
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (nutop + N), 1, nutop, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha, (nutop + N), 1, nutop, 1);
   // Add - 6*row2
   alpha = -6.f;
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (nutop + (2 * N)), 1, nutop, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha, (nutop + (2 * N)), 1, nutop, 1);
   // Add (11/3)*row3
   alpha = (11.f/3.f);
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (nutop + (3 * N)), 1, nutop, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha, (nutop + (3 * N)), 1, nutop, 1);
   // Divide the array by 2*DX
   alpha = 1.f/(2.f*DX);
-  oneapi::mkl::blas::column_major::scal(q, 4 * N, alpha, nutop, 1);
+  math_ns::blas::column_major::scal(q, 4 * N, alpha, nutop, 1);
   // Elementwise multiplication with trnu
   q.parallel_for(
     sycl::nd_range<2>(gws, lws), [=](sycl::nd_item<2> item) {
@@ -219,7 +225,7 @@ float NusseltCompute(sycl::queue &q, float *T, float *nutop, float *ztop,
   // a row that has been altered to be all 1s.
   // Empty row1, then add 1 to all its elements
   alpha = 0.f;
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, (nutop + N), 1);
+  math_ns::blas::column_major::scal(q, N, alpha, (nutop + N), 1);
   q.parallel_for(
     sycl::nd_range<2>(gws, lws), [=](sycl::nd_item<2> item) {
       AddOne(nutop + N, item);
@@ -227,25 +233,25 @@ float NusseltCompute(sycl::queue &q, float *T, float *nutop, float *ztop,
 
   float *result;
   result = sycl::malloc_shared<float>(1, q);
-  oneapi::mkl::blas::column_major::dot(q, N, nutop, 1, (nutop + N), 1, result).wait();
+  math_ns::blas::column_major::dot(q, N, nutop, 1, (nutop + N), 1, result).wait();
   topsum = *result /(-XF);
 
   // Calculate the Nusselt number along the bottom of the array.
   // d_nubot's first row is all 1, and ith row is the i-1th row of d_T
   // Put the first row of T in nubot, then subtract to get 0, then AddOne
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, nubot, 1);
+  math_ns::blas::column_major::scal(q, N, alpha, nubot, 1);
   q.parallel_for(
     sycl::nd_range<2>(gws, lws), [=](sycl::nd_item<2> item) {
       AddOne(nubot, item);
   });
-  oneapi::mkl::blas::column_major::copy(q, N, T, 1, (nubot + N), 1);
-  oneapi::mkl::blas::column_major::copy(q, N, (T + N), 1, (nubot + 2 * N), 1);
-  oneapi::mkl::blas::column_major::copy(q, N, (T + 2 * N), 1, (nubot + 3 * N), 1);
+  math_ns::blas::column_major::copy(q, N, T, 1, (nubot + N), 1);
+  math_ns::blas::column_major::copy(q, N, (T + N), 1, (nubot + 2 * N), 1);
+  math_ns::blas::column_major::copy(q, N, (T + 2 * N), 1, (nubot + 3 * N), 1);
 
   // nubot += -( 1 - zbot)
   // => nubot += zbot; nubot -= 1
   alpha = 1.f;
-  oneapi::mkl::blas::column_major::axpy(q, 4 * N, alpha, zbot, 1, nubot, 1);
+  math_ns::blas::column_major::axpy(q, 4 * N, alpha, zbot, 1, nubot, 1);
   // Subtract 1 from every element in the array.  SubOne works on rows.
   q.parallel_for(
     sycl::nd_range<2>(gws, lws), [=](sycl::nd_item<2> item) {
@@ -268,19 +274,19 @@ float NusseltCompute(sycl::queue &q, float *T, float *nutop, float *ztop,
   // accumulate in the 0th row
   // scale the 0th row by -(11/3)
   alpha = -(11.f/3.f);
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, nubot, 1);
+  math_ns::blas::column_major::scal(q, N, alpha, nubot, 1);
   // Add 6*row1
   alpha = 6.f;
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (nubot + N), 1, nubot, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha, (nubot + N), 1, nubot, 1);
   // Add -3*row2
   alpha = -3.f;
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (nubot + (2 * N)), 1, nubot, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha, (nubot + (2 * N)), 1, nubot, 1);
   // Add (2/3)*row3
   alpha = 2.f/3.f;
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (nubot + (3 * N)), 1, nubot, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha, (nubot + (3 * N)), 1, nubot, 1);
   // Divide the array by 2*DX
   alpha = 1.f/(2.f*DX);
-  oneapi::mkl::blas::column_major::scal(q, 4 * N, alpha, nubot, 1);
+  math_ns::blas::column_major::scal(q, 4 * N, alpha, nubot, 1);
   // Elementwise multiplication with trnu
   q.parallel_for(
     sycl::nd_range<2>(gws, lws), [=](sycl::nd_item<2> item) {
@@ -289,7 +295,7 @@ float NusseltCompute(sycl::queue &q, float *T, float *nutop, float *ztop,
   // Sum up the elements of row0, by performing a dot product with
   // a row that has been altered to be all 1s.
   // The second row of nutop has already been set up for this.
-  oneapi::mkl::blas::column_major::dot(q, N, nubot, 1, (nutop + N), 1, result).wait();
+  math_ns::blas::column_major::dot(q, N, nubot, 1, (nutop + N), 1, result).wait();
   botsum = *result /(-XF);
 
   sycl::free(result, q);
@@ -312,22 +318,22 @@ void Dz(sycl::queue &q, float *f, int is_it_psi, float *y) {
   // Move all but the first two rows of f into the interior rows of y.
   // The end of one row is one element away from the beginning of the next,
   // so adjacent rows are laid out in memory identically to a vector.
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 4), (f + (2 * N)), 1,
+  math_ns::blas::column_major::copy(q, N * (M - 4), (f + (2 * N)), 1,
                                         (y + N), 1);
   // Subtract all but the last two rows of f.
   const float alpha = -1.f;
   const float alpha2 = 1.f/(2.f*DX);
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 4), alpha, f, 1, (y + N), 1);
+  math_ns::blas::column_major::axpy(q, N * (M - 4), alpha, f, 1, (y + N), 1);
 
   if(is_it_psi == 1) {
     // yrows[0] = frows[1]
     // Move the second row of f into the first row of y
-    oneapi::mkl::blas::column_major::copy(q, N, (f + N), 1, y, 1);
+    math_ns::blas::column_major::copy(q, N, (f + N), 1, y, 1);
   }
   else {
     // yrows[0] = frows[1] - 1
     // Move the second row of f into the first row of y
-    oneapi::mkl::blas::column_major::copy(q, N, (f + N), 1, y, 1);
+    math_ns::blas::column_major::copy(q, N, (f + N), 1, y, 1);
     // Subtract 1 from every element in the first row of y.
    sycl::range<2> gws (1, (floorf(N / 256.f) + 1) * 256);
    sycl::range<2> lws (1, 256);
@@ -339,12 +345,12 @@ void Dz(sycl::queue &q, float *f, int is_it_psi, float *y) {
 
   // yrows[M-3] = -frows[M-4]
   // Copy the second-to-last row of f into the last row of y
-  oneapi::mkl::blas::column_major::copy(q, N, (f + ((M - 4) * N)), 1,
+  math_ns::blas::column_major::copy(q, N, (f + ((M - 4) * N)), 1,
                                         (y + (M - 3) * N), 1);
   // Scale by -1.f
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, (y + (M - 3) * N), 1);
+  math_ns::blas::column_major::scal(q, N, alpha, (y + (M - 3) * N), 1);
   // Scale y by 1/(2*DX)
-  oneapi::mkl::blas::column_major::scal(q, N * (M - 2), alpha2, y, 1);
+  math_ns::blas::column_major::scal(q, N * (M - 2), alpha2, y, 1);
 }
 
 //=============================================================================
@@ -360,29 +366,29 @@ void Dz(sycl::queue &q, float *f, int is_it_psi, float *y) {
 void Dzz(sycl::queue &q, float *f, float *y) {
   // yrows[i] = frows[i - 1] - 2*frows[i] + frows[i + 1]
   // Move all but the last two rows of f into the interior rows of y.
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 4), f, 1, (y + N), 1);
+  math_ns::blas::column_major::copy(q, N * (M - 4), f, 1, (y + N), 1);
 
   const float alpha = -2.f;
   const float alpha2 = 1.f;
   const float alpha3 = 1.f/DX2;
 
   // Subtract 2* the interior rows of f
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 4), alpha, (f + N), 1,
+  math_ns::blas::column_major::axpy(q, N * (M - 4), alpha, (f + N), 1,
                                         (y + N), 1);
 
   // Add all but the first two rows of f.
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 4), alpha2, (f + (2 * N)),
+  math_ns::blas::column_major::axpy(q, N * (M - 4), alpha2, (f + (2 * N)),
                                         1, (y + N), 1);
 
   // yrows[0] = 1 - 2*frows[0] + frows[1]
   // Copy the first row of f into the first row of y
-  oneapi::mkl::blas::column_major::copy(q, N, f, 1, y, 1);
+  math_ns::blas::column_major::copy(q, N, f, 1, y, 1);
 
   // scale by -2
-  oneapi::mkl::blas::column_major::scal(q, N, alpha, y, 1);
+  math_ns::blas::column_major::scal(q, N, alpha, y, 1);
 
   // add the second row of f
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha2, (f + N), 1, y, 1);
+  math_ns::blas::column_major::axpy(q, N, alpha2, (f + N), 1, y, 1);
 
   // Add 1 to every element in the first row of y.
   sycl::range<2> gws (1, (floorf(N / 256.f) + 1) * 256);
@@ -394,13 +400,13 @@ void Dzz(sycl::queue &q, float *f, float *y) {
 
   // yrows[M-3] = frows[M-4] - 2*frows[M-3]
   // move the second-to-last row of f into the last row of y
-  oneapi::mkl::blas::column_major::copy(q, N, (f + (M - 4) * N), 1,
+  math_ns::blas::column_major::copy(q, N, (f + (M - 4) * N), 1,
                                         (y + (M - 3) * N), 1);
   // subtract -2* the last row of f
-  oneapi::mkl::blas::column_major::axpy(q, N, alpha, (f + (M - 3) * N), 1,
+  math_ns::blas::column_major::axpy(q, N, alpha, (f + (M - 3) * N), 1,
                                         (y + (M - 3) * N), 1);
   // Scale y by 1/DX2
-  oneapi::mkl::blas::column_major::scal(q, (M - 2) * N, alpha3, y, 1);
+  math_ns::blas::column_major::scal(q, (M - 2) * N, alpha3, y, 1);
 }
 
 //=============================================================================
@@ -421,13 +427,13 @@ void Dx(sycl::queue &q, float *f, int is_it_psi, float *y) {
   // for longer vectors.
 
   for(int i = 0; i < M - 2; i++) {
-    oneapi::mkl::blas::column_major::copy(q, (N - 2), (f + i * N) + 2, 1,
+    math_ns::blas::column_major::copy(q, (N - 2), (f + i * N) + 2, 1,
                                           (y + i * N) + 1, 1);
   }
   // Subtract the block corresponding to all but the last two columns of f.
   float alpha = -1.f;
   for(int i = 0; i < M - 2; i++) {
-    oneapi::mkl::blas::column_major::axpy(q, (N - 2), alpha, (f + i * N), 1,
+    math_ns::blas::column_major::axpy(q, (N - 2), alpha, (f + i * N), 1,
                                           (y + i * N) + 1, 1);
   }
 
@@ -437,40 +443,40 @@ void Dx(sycl::queue &q, float *f, int is_it_psi, float *y) {
     float alpha3 = 2.f/3.f;
     // ycols[0] = 6*fcols[1] - 3*fcols[2] + (2/3)*fcols[3]
     // Begin by copying the second column of f into the first column of y
-    oneapi::mkl::blas::column_major::copy(q, (M - 2), (f + 1), N, y, N);
+    math_ns::blas::column_major::copy(q, (M - 2), (f + 1), N, y, N);
     // Scale it by a factor of 6
-    oneapi::mkl::blas::column_major::scal(q, (M - 2), alpha, y, N);
+    math_ns::blas::column_major::scal(q, (M - 2), alpha, y, N);
     // Subtract the third column of 3*f
-    oneapi::mkl::blas::column_major::axpy(q, (M - 2), alpha2, (f + 2), N, y, N);
+    math_ns::blas::column_major::axpy(q, (M - 2), alpha2, (f + 2), N, y, N);
     // Add the fourth column of (2/3)*f
-    oneapi::mkl::blas::column_major::axpy(q, (M - 2), alpha3, (f + 3), N, y, N);
+    math_ns::blas::column_major::axpy(q, (M - 2), alpha3, (f + 3), N, y, N);
 
     alpha = -alpha;
     alpha2 = -alpha2;
     alpha3 = -alpha3;
     //ycols[N-1] = -6*fcols[N-2] + 3*fcols[N-3] - (2/3)*fcols[N-4]
     // Copy the second-to-last column of f into the last column of y
-    oneapi::mkl::blas::column_major::copy(q, (M - 2), (f + (N - 2)), N,
+    math_ns::blas::column_major::copy(q, (M - 2), (f + (N - 2)), N,
                                           (y + (N - 1)), N);
     // Scale it by a factor of -6
-    oneapi::mkl::blas::column_major::scal(q, (M - 2), alpha, (y + (N - 1)), N);
+    math_ns::blas::column_major::scal(q, (M - 2), alpha, (y + (N - 1)), N);
     // Add the third-to-last column of 3*fcols[N-3]
-    oneapi::mkl::blas::column_major::axpy(q, (M - 2), alpha2, (f + (N - 3)), N,
+    math_ns::blas::column_major::axpy(q, (M - 2), alpha2, (f + (N - 3)), N,
                                           (y + (N - 1)), N);
     // Subtract the fourth-to-last column of (2/3)*f[N-4]
-    oneapi::mkl::blas::column_major::axpy(q, (M - 2), alpha3, (f + (N - 4)), N,
+    math_ns::blas::column_major::axpy(q, (M - 2), alpha3, (f + (N - 4)), N,
                                           (y + (N - 1)), N);
   }
   else {
     // outside columns = 0
     const float alpha = 0.f;
-    oneapi::mkl::blas::column_major::scal(q, (M - 2), alpha, y, N);
-    oneapi::mkl::blas::column_major::scal(q, (M - 2), alpha, (y + (N - 1)), N);
+    math_ns::blas::column_major::scal(q, (M - 2), alpha, y, N);
+    math_ns::blas::column_major::scal(q, (M - 2), alpha, (y + (N - 1)), N);
   }
 
   // Scale y by (1/(2*DX))
   alpha = (1.f/(2.f*DX));
-  oneapi::mkl::blas::column_major::scal(q, N * (M - 2), alpha, y, 1);
+  math_ns::blas::column_major::scal(q, N * (M - 2), alpha, y, 1);
 }
 
 //=============================================================================
@@ -492,40 +498,40 @@ void Dxx(sycl::queue &q, float *f, float *y) {
 
   // ycols[i] = fcols[i-1] - 2*fcols[i] + fcols[i+1], interior columns
   // copy f into y
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, y, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, y, 1);
   // scale by -2
-  oneapi::mkl::blas::column_major::scal(q, N * (M - 2), alpha, y, 1);
+  math_ns::blas::column_major::scal(q, N * (M - 2), alpha, y, 1);
   // Add the block corresponding to all but the last two columns of f.
   for(int i = 0; i < M-2; i++) {
-    oneapi::mkl::blas::column_major::axpy(q, (N - 2), alpha3, (f + i * N), 1,
+    math_ns::blas::column_major::axpy(q, (N - 2), alpha3, (f + i * N), 1,
                                           (y + i * N) + 1, 1);
   }
   // Add the block corresponding to all but the first two columns of f.
   for(int i = 0; i < M-2; i++) {
-    oneapi::mkl::blas::column_major::axpy(q, (N - 2), alpha3, (f + i * N) + 2,
+    math_ns::blas::column_major::axpy(q, (N - 2), alpha3, (f + i * N) + 2,
                                           1, (y + i * N) + 1, 1);
   }
 
   // ycols[0] = -2*fcols[0] + 2*fcols[1]
   // Copy the first column of f into the first column of y.
-  oneapi::mkl::blas::column_major::copy(q, (M - 2), f, N, y, N);
+  math_ns::blas::column_major::copy(q, (M - 2), f, N, y, N);
   // Scale the first column of y by -2.f
-  oneapi::mkl::blas::column_major::scal(q, (M - 2), alpha, y, N);
+  math_ns::blas::column_major::scal(q, (M - 2), alpha, y, N);
   // Add 2* the second column of f.
-  oneapi::mkl::blas::column_major::axpy(q, (M - 2), alpha2, (f + 1), N, y, N);
+  math_ns::blas::column_major::axpy(q, (M - 2), alpha2, (f + 1), N, y, N);
 
   // ycols[N-1] = -2*fcols[N-1] + 2*fcols[N-2]
   // Move the last column of f into the last column of y
-  oneapi::mkl::blas::column_major::copy(q, (M - 2), (f + (N - 1)), N,
+  math_ns::blas::column_major::copy(q, (M - 2), (f + (N - 1)), N,
                                         (y + (N - 1)), N);
   // Scale by -2.f
-  oneapi::mkl::blas::column_major::scal(q, (M - 2), alpha, (y + (N - 1)), N);
+  math_ns::blas::column_major::scal(q, (M - 2), alpha, (y + (N - 1)), N);
   // add 2* the second-to-last column of f.
-  oneapi::mkl::blas::column_major::axpy(q, (M - 2), alpha2, (f + (N - 2)), N,
+  math_ns::blas::column_major::axpy(q, (M - 2), alpha2, (f + (N - 2)), N,
                                         (y + (N - 1)), N);
 
   // Scale y by 1/(DX^2)
-  oneapi::mkl::blas::column_major::scal(q, N * (M - 2), alpha4, y, 1);
+  math_ns::blas::column_major::scal(q, N * (M - 2), alpha4, y, 1);
 }
 
 //=============================================================================
@@ -544,13 +550,13 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
 
   // Define omega to be the interior columns of Dxf
   // Save Dx of f in DxT for later
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, DxT, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, DxT, 1);
 
   Dx(q, f, 0, DxT);
 
   // Copy the interior columns of DxT to omega
   for(int i = 0; i < M-2; i ++) {
-    oneapi::mkl::blas::column_major::copy(q, (N - 2), (DxT + i * N) + 1, 1,
+    math_ns::blas::column_major::copy(q, (N - 2), (DxT + i * N) + 1, 1,
                                           (omega + i * (N - 2)), 1);
   }
 
@@ -574,19 +580,19 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
   const float alpha2 = -1.f;
   const float beta = 0.f;
 
-  oneapi::mkl::blas::column_major::gemm(
-      q, oneapi::mkl::transpose::nontrans, oneapi::mkl::transpose::nontrans,
+  math_ns::blas::column_major::gemm(
+      q, math_ns::transpose::nontrans, math_ns::transpose::nontrans,
       N - 2, M - 2, M - 2, alpha, omega, N - 2, dsc,
       M - 2, beta, Tbuff, N - 2);
-  oneapi::mkl::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega, 1);
+  math_ns::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega, 1);
 
   // Perform Tranpose(dsr)*Transpose(omega), store in omega.
   // since A is square, M = k = N-2, so n must be M-2.
-  oneapi::mkl::blas::column_major::gemm(
-      q, oneapi::mkl::transpose::nontrans, oneapi::mkl::transpose::nontrans,
+  math_ns::blas::column_major::gemm(
+      q, math_ns::transpose::nontrans, math_ns::transpose::nontrans,
       N - 2, M - 2, N - 2, alpha, dsr, N - 2, omega,
       N - 2, beta, Tbuff, N - 2);
-  oneapi::mkl::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega, 1);
+  math_ns::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega, 1);
 
   // elementwise matrix multiplication, storing the result in omega
   //DEBUG
@@ -595,44 +601,44 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
   });
 
   // same Transpose(omega)*Transpose(dsc) operation as before
-  oneapi::mkl::blas::column_major::gemm(
-      q, oneapi::mkl::transpose::nontrans, oneapi::mkl::transpose::nontrans,
+  math_ns::blas::column_major::gemm(
+      q, math_ns::transpose::nontrans, math_ns::transpose::nontrans,
       N - 2, M - 2, M - 2, alpha, omega, N - 2, dsc,
       M - 2, beta, Tbuff, N - 2);
-  oneapi::mkl::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega,
+  math_ns::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega,
                                         1);
 
   // same Transpose(dsr)*Transpose(omega) operation as before
-  oneapi::mkl::blas::column_major::gemm(
-      q, oneapi::mkl::transpose::nontrans, oneapi::mkl::transpose::nontrans,
+  math_ns::blas::column_major::gemm(
+      q, math_ns::transpose::nontrans, math_ns::transpose::nontrans,
       N - 2, M - 2, N - 2, alpha, dsr, N - 2, omega,
       N - 2, beta, Tbuff, N - 2);
-  oneapi::mkl::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega, 1);
+  math_ns::blas::column_major::copy(q, (N - 2) * (M - 2), Tbuff, 1, omega, 1);
 
   // Scale omega by -(DX^4)*(RA) = OMEGACOEFF
   const float omegacoeff = OMEGACOEFF;
-  oneapi::mkl::blas::column_major::scal(q, (N - 2) * (M - 2), omegacoeff, omega, 1);
+  math_ns::blas::column_major::scal(q, (N - 2) * (M - 2), omegacoeff, omega, 1);
 
   // interior columns of psi = (RA*DX^4)*omega
   // copy omega into the interior columns of psi
   // omega has rows of length N-2 instead of N
 
   for(int i = 0; i < M-2; i ++) {
-    oneapi::mkl::blas::column_major::copy(q, (N - 2), (omega + i * (N - 2)), 1,
+    math_ns::blas::column_major::copy(q, (N - 2), (omega + i * (N - 2)), 1,
                                           (psi + i * N) + 1, 1);
   }
 
   // Velocity in the x-direction
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, u, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, u, 1);
   Dz(q, psi, 1, u);
 
   // v is -Dxpsi, velocity in the z direction.
   // Place Dxpsi into v
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, v, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, v, 1);
   Dx(q, psi, 1, v);
 
   // Change the sign of v.
-  oneapi::mkl::blas::column_major::scal(q, (M - 2) * N, alpha2, v, 1);
+  math_ns::blas::column_major::scal(q, (M - 2) * N, alpha2, v, 1);
   // Store v in the z velocity file
 
   // If compute_velocity = 1, we need to update dt
@@ -640,14 +646,14 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
     // CublasIdamax returns 1-indexed pointers into the max element of a
     // float-precision vector
     int64_t *iu = sycl::malloc_shared<int64_t>(1, q);
-    auto e_iu = oneapi::mkl::blas::column_major::iamax(
-        q, N * (M - 2), u, 1, iu, oneapi::mkl::index_base::one);
+    auto e_iu = math_ns::blas::column_major::iamax(
+        q, N * (M - 2), u, 1, iu, math_ns::index_base::one);
     int64_t *iv = sycl::malloc_shared<int64_t>(1, q);
-    auto e_iv = oneapi::mkl::blas::column_major::iamax(
-        q, N * (M - 2), v, 1, iv, oneapi::mkl::index_base::one);
+    auto e_iv = math_ns::blas::column_major::iamax(
+        q, N * (M - 2), v, 1, iv, math_ns::index_base::one);
     q.submit([&] (sycl::handler& cgh) {
       cgh.depends_on({e_iu, e_iv});
-      cgh.single_task<class update_dt>([=] () { 
+      cgh.single_task<class update_dt>([=] () {
         Updatedt(iu[0], u, iv[0], v, dt);
       });
     }).wait();
@@ -656,16 +662,16 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
   }
 
   // Place Dxxf into y
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, y, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, y, 1);
   Dxx(q, f, y);
 
   // y = y + Dzzf
   // place Dzzf into Tbuff
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, Tbuff, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, Tbuff, 1);
   Dzz(q, f, Tbuff);
 
   // Add the elements of y and Tbuff, storing in y.
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, Tbuff, 1, y, 1);
+  math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, Tbuff, 1, y, 1);
 
   // u = u.*DxT, where .* denotes elementwise multiplication
   // Perform the elentwise multiplication, storing in u
@@ -675,10 +681,10 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
 
   // y = y + u
   // Add y and u, storing the result in y
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, u, 1, y, 1);
+  math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, u, 1, y, 1);
 
   // u = DzT
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), f, 1, u, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), f, 1, u, 1);
 
   Dz(q, f, 0, u);
 
@@ -688,10 +694,10 @@ void G(sycl::queue &q, float *f, float *Tbuff, float *DxT, float *y,
   });
 
   // y = y + u
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, u, 1, y, 1);
+  math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, u, 1, y, 1);
 
   // copy into output
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), y, 1, output, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), y, 1, output, 1);
 }
 
 
@@ -912,25 +918,25 @@ int main(int argc, char *argv[]) {
 
   // use d_T to define d_psi, d_u, d_v, and d_y = 0.
   float alpha = -1.f;
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_psi, 1);
-  oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, d_psi, 1, d_psi,
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_psi, 1);
+  math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, d_psi, 1, d_psi,
                                         1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_psi, 1, d_u, 1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_psi, 1, d_v, 1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_psi, 1, d_y, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_psi, 1, d_u, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_psi, 1, d_v, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_psi, 1, d_y, 1);
 
   //initialize all intermediate matrices to T;
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_xrk3, 1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_yrk3, 1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_zrk3, 1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_Tbuff, 1);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_DxT, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_xrk3, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_yrk3, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_zrk3, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_Tbuff, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_DxT, 1);
 
   // DEBUG
   // temporary buffer for use in d_*rk3 stuff
   float* d_temp;
   d_temp = sycl::malloc_device<float>(N * (M - 2), q);
-  oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_temp, 1);
+  math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_temp, 1);
 
   printf("Begin computation: \n");
 
@@ -957,9 +963,9 @@ int main(int argc, char *argv[]) {
     // add (dt/3)*d_xrk3 to T, store the result in T temporarily.
     //    cublasSaxpy(h, N*(M-2), (dt/3.f), d_xrk3, 1, d_T, 1);
     //DEBUG
-    oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_temp, 1);
+    math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_temp, 1);
     alpha = dt/3.f;
-    oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, d_xrk3, 1,
+    math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, d_xrk3, 1,
                                           d_temp, 1);
     // Compute d_yrk3 = g(T + (dt/3)*d_xrk3, 0) by using the updated T.
     //    SHORTG(d_T, 0, d_yrk3);
@@ -972,9 +978,9 @@ int main(int argc, char *argv[]) {
     // Add (2*dt/3)*d_yrk3 to T, store the result in T temporarily.
     //    cublasSaxpy(h, N*(M-2), (2.f*(dt/3)), d_yrk3, 1, d_T, 1);
     //DEBUG
-    oneapi::mkl::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_temp, 1);
+    math_ns::blas::column_major::copy(q, N * (M - 2), d_T, 1, d_temp, 1);
     alpha = 2.f*(dt/3.f);
-    oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, d_yrk3, 1,
+    math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, d_yrk3, 1,
                                           d_temp, 1);
     // Compute d_zrk3 = g(T + (2*dt/3)*d_yrk3) by using the updated T.
     //    SHORTG(d_T, 1, d_zrk3);
@@ -991,10 +997,10 @@ int main(int argc, char *argv[]) {
     //    cublasSaxpy(h, N*(M-2), (3.f*(dt/4.f)), d_zrk3, 1, d_T, 1);
     //DEBUG
     alpha = dt/4.f;
-    oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, d_xrk3, 1,
+    math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, d_xrk3, 1,
                                           d_T, 1);
     alpha = 3.f * alpha;
-    oneapi::mkl::blas::column_major::axpy(q, N * (M - 2), alpha, d_zrk3, 1,
+    math_ns::blas::column_major::axpy(q, N * (M - 2), alpha, d_zrk3, 1,
                                           d_T, 1);
 
     // update the value of dt (in host) from d_dt (in device)


### PR DESCRIPTION
## Summary

This PR adds OneMath API support to multiple benchmarks and improves verification.

- **OneMath API Integration**: Added OneMath support via `USE_ONEMATH` macro as an alternative to OneMKL
- **AdaptiveCpp Compatibility**: Enhanced support for non-DPCPP compilers by skipping unsupported data types (And supporting Onemath API)
- **Verification Improvements**: Add missing verification and change some verification threshold 

## Detail by benchmarks :


**gemmStridedBatched & gemmBatched**
- OneMath API support via `USE_ONEMATH` macro
- Clarify verification output with explicit PASS/FAIL messages

**gemm**
- OneMath API support via `USE_ONEMATH` macro
- Replace `mkl_malloc` with standard SYCL allocation
- Add tolerance-based verification for improved accuracy

**gemmEx**
- OneMath API support via `USE_ONEMATH` macro
- Add AdaptiveCpp support by skipping bf16 and int8 tests for non-DPCPP compilers
- Enhanced verification for SYCL variant

**dot**
- OneMath and AdaptiveCpp support
- Skip FP16/BF16 compilation for non-DPCPP compilers
- set verification threshold to 1% of sum (instead of 1e-1) for fp32

**norm2**
- Standard oneMKL linking in Makefile
- OneMath API support via `USE_ONEMATH` macro
- Set verification threshold to 1% 

**dropout**
- OneMath API support via `USE_ONEMATH` macro

**rayleighBenardConvection**
- OneMath API support via `USE_ONEMATH` macro