### PR TITLE
[svt] add sparse volume traversal benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Each benchmark falls into a single category. While such classification is not ac
     extrema, fft, lombscargle, sosfil, zmddft
 
 ### Simulation
-    ace, adv, amgmk, axhelm, bh, bspline-vgh, burger, cooling, ccsd-trpdrv, che, chemv, chi2, clenergy, cmp, cobahh, d2q9_bgk, d3q19_bgk, damage, ddbp, dslash, easyWave, eikonal, fdtd3d, feynman-kac, fhd, fluidSim, gibbs, goulash, gpp, grrt, haccmk, halo-finder, heartwall, heat, heat2d, henry, hexicton, hotspot, hotspot3D, hpl, hwt1d, hypterm, ising, iso2dfd, laplace, laplace3d, lavaMD, lid-driven-cavity, logic-resim, logic-rewrite, loopback, lsqt, lulesh, mcmd, md, mdh, metropolis, miniFE, minimod, minisweep, miniWeather, multimaterial, mxfp4, myocte, nbody, particle-diffusion, particlefilter, particles, pathfinder, pns, projectile, pso, qem, rainflow, rayleighBenardConvection, reaction, rsbench, rtm8, rushlarsen, s3d, su3, sundials, sheath, simplemoc, slit, sparkler, sph, sw4ck, tensorT, testSNAP, tissue, tpacf, tqs, tridiagonal, tsa, vanGenuchten, vmc, wenofv, wlcpow, wsm5, xlqc, xsbench
+    ace, adv, amgmk, axhelm, bh, bspline-vgh, burger, cooling, ccsd-trpdrv, che, chemv, chi2, clenergy, cmp, cobahh, d2q9_bgk, d3q19_bgk, damage, ddbp, dslash, easyWave, eikonal, fdtd3d, feynman-kac, fhd, fluidSim, gibbs, goulash, gpp, grrt, haccmk, halo-finder, heartwall, heat, heat2d, henry, hexicton, hotspot, hotspot3D, hpl, hwt1d, hypterm, ising, iso2dfd, laplace, laplace3d, lavaMD, lid-driven-cavity, logic-resim, logic-rewrite, loopback, lsqt, lulesh, mcmd, md, mdh, metropolis, miniFE, minimod, minisweep, miniWeather, multimaterial, mxfp4, myocte, nbody, particle-diffusion, particlefilter, particles, pathfinder, pns, projectile, pso, qem, rainflow, rayleighBenardConvection, reaction, rsbench, rtm8, rushlarsen, s3d, su3, sundials, sheath, simplemoc, slit, sparkler, sph, svt, sw4ck, tensorT, testSNAP, tissue, tpacf, tqs, tridiagonal, tsa, vanGenuchten, vmc, wenofv, wlcpow, wsm5, xlqc, xsbench
 
 ### Sorting
     bitonic-sort, hybridsort, is, merge, quicksort, radixsort, segsort, sort, sortKV, split, topk, warpsort
@@ -1709,6 +1709,9 @@ Early results are shown [here](results/README.md)
 
 ### svd3x3 (cuda)
   Compute the singular value decomposition of 3x3 matrices (https://github.com/kuiwuchn/3x3_SVD_CUDA)
+
+### svt (cuda)
+  Sparse volume traversal using two-level DDA ray casting through a procedurally generated TSDF volume (https://github.com/AcademySoftwareFoundation/openvdb/tree/master/nanovdb)
 
 ### sw4ck (cuda)
   SW4 curvilinear kernels are five stencil kernels that account for ~50% of the solution time in SW4 (https://github.com/LLNL/SW4CK)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,6 +289,7 @@ set(HECBENCH_POC_BENCHMARKS
     murmurhash3
     mxfp4
     myocyte
+    svt
     nbnxm
     nbody
     ne

--- a/src/svt-cuda/CMakeLists.txt
+++ b/src/svt-cuda/CMakeLists.txt
@@ -1,0 +1,11 @@
+# svt-cuda/CMakeLists.txt
+
+add_hecbench_benchmark(
+    NAME svt
+    MODEL cuda
+    SOURCES main.cu
+    CATEGORIES simulation
+    TEST_ARGS 12 1280 720 100
+    TEST_REGEX "Raycast: PASS"
+    TEST_TIMEOUT 300
+)

--- a/src/svt-cuda/Makefile
+++ b/src/svt-cuda/Makefile
@@ -53,4 +53,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) 12 1280 720 100
+	$(LAUNCHER) ./$(program) 12 1280 720 1000

--- a/src/svt-cuda/Makefile
+++ b/src/svt-cuda/Makefile
@@ -1,0 +1,56 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+# Compiler can be set below, or via environment variable
+CC        = nvcc
+OPTIMIZE  = yes
+DEBUG     = no
+ARCH      = sm_60
+LAUNCHER  ?=
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = main
+
+source = main.cu
+
+obj = $(source:.cu=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Xcompiler -Wall -arch=$(ARCH)
+
+# Linker Flags
+LDFLAGS =
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g -DDEBUG
+  LDFLAGS  += -g
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) Makefile
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cu reference.h Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+run: $(program)
+	$(LAUNCHER) ./$(program) 12 1280 720 100

--- a/src/svt-cuda/main.cu
+++ b/src/svt-cuda/main.cu
@@ -1,0 +1,343 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <chrono>
+#include <vector>
+#include <cuda.h>
+
+#include "reference.h"
+
+#define CHECK(call)                                                      \
+  do {                                                                   \
+    cudaError_t err = (call);                                            \
+    if (err != cudaSuccess) {                                            \
+      fprintf(stderr, "CUDA error at %s:%d: %s\n",                      \
+              __FILE__, __LINE__, cudaGetErrorString(err));              \
+      exit(EXIT_FAILURE);                                                \
+    }                                                                    \
+  } while (0)
+
+// ---------------------------------------------------------------------------
+// device helpers (same algorithms as reference.h, adapted for CUDA)
+// ---------------------------------------------------------------------------
+
+// Generate a primary ray for pixel (px, py) from the camera.
+// Computes the ray origin (camera eye) and a normalized direction vector
+// using the camera's right/up/forward basis and field-of-view scale.
+__device__ __forceinline__
+void d_generate_ray(const Camera cam, int px, int py,
+                    float* origin, float* dir)
+{
+  const float aspect = (float)cam.width * cam.inv_height;
+  const float u = (2.0f * (px + 0.5f) * cam.inv_width  - 1.0f) *
+                  cam.fov_scale * aspect;
+  const float v = (2.0f * (py + 0.5f) * cam.inv_height - 1.0f) *
+                  cam.fov_scale;
+  for (int k = 0; k < 3; k++) {
+    origin[k] = cam.eye[k];
+    dir[k] = u * cam.right[k] + v * cam.up[k] + cam.forward[k];
+  }
+  float inv_dn = rsqrtf(dir[0]*dir[0] + dir[1]*dir[1] + dir[2]*dir[2]);
+  for (int k = 0; k < 3; k++) dir[k] *= inv_dn;
+}
+
+// Ray–AABB intersection test against the unit cube [0,1]^3.
+// Returns true if the ray hits the box, storing the entry and exit
+// distances in t_near and t_far (clamped so t_near >= 0).
+__device__ __forceinline__
+bool d_ray_box(const float* origin, const float* dir,
+               float* t_near, float* t_far)
+{
+  float tmin = -1e30f, tmax = 1e30f;
+  for (int k = 0; k < 3; k++) {
+    if (fabsf(dir[k]) < 1e-8f) {
+      if (origin[k] < 0.0f || origin[k] > 1.0f) return false;
+    } else {
+      float inv = 1.0f / dir[k];
+      float t1 = -origin[k] * inv;
+      float t2 = (1.0f - origin[k]) * inv;
+      if (t1 > t2) { float tmp = t1; t1 = t2; t2 = tmp; }
+      tmin = fmaxf(tmin, t1);
+      tmax = fminf(tmax, t2);
+    }
+  }
+  *t_near = fmaxf(tmin, 0.0f);
+  *t_far  = tmax;
+  return *t_near < *t_far;
+}
+
+// Look up the TSDF value at global voxel coordinates (vx, vy, vz).
+// Converts global coords to block index + local offset, returning 1.0
+// (outside) for out-of-bounds or inactive blocks.
+__device__ __forceinline__
+float d_lookup_tsdf(const int* block_offset, const float* leaf_data,
+                    int vx, int vy, int vz)
+{
+  if (vx < 0 || vx >= VOXEL_DIM ||
+      vy < 0 || vy >= VOXEL_DIM ||
+      vz < 0 || vz >= VOXEL_DIM) return 1.0f;
+
+  int bx = vx >> LEAF_LOG2, by = vy >> LEAF_LOG2, bz = vz >> LEAF_LOG2;
+  int bi = (bx * GRID_DIM + by) * GRID_DIM + bz;
+  int off = block_offset[bi];
+  if (off < 0) return 1.0f;
+
+  int lx = vx & LEAF_MASK, ly = vy & LEAF_MASK, lz = vz & LEAF_MASK;
+  return leaf_data[(size_t)off * LEAF_VOXELS +
+                   (lx * LEAF_DIM + ly) * LEAF_DIM + lz];
+}
+
+// Two-level DDA ray caster through the sparse TSDF volume.
+// First traverses the coarse block grid (GRID_DIM^3) with a 3-D DDA,
+// then for each active block runs a fine-grained voxel-level DDA
+// (LEAF_DIM^3) to detect zero crossings. On a positive-to-negative
+// TSDF transition, linearly interpolates the hit distance and computes
+// the surface normal via central differences.
+__device__
+bool d_cast_ray(const float* origin, const float* dir,
+                const int* block_offset, const float* leaf_data,
+                float* hit_t, float* hit_normal)
+{
+  float t_near, t_far;
+  if (!d_ray_box(origin, dir, &t_near, &t_far)) return false;
+
+  float inv_dir[3];
+  int   step[3];
+  for (int k = 0; k < 3; k++) {
+    inv_dir[k] = (fabsf(dir[k]) > 1e-8f) ? (1.0f / dir[k]) : 1e8f;
+    step[k]    = (dir[k] >= 0.0f) ? 1 : -1;
+  }
+
+  float entry[3];
+  for (int k = 0; k < 3; k++)
+    entry[k] = fmaxf(0.0f, fminf(origin[k] + t_near * dir[k], 1.0f - 1e-6f));
+
+  int   bi[3];
+  float tMax[3], tDelta[3];
+  for (int k = 0; k < 3; k++) {
+    bi[k] = min(GRID_DIM - 1, max(0, (int)(entry[k] / BLOCK_W)));
+    float boundary = (step[k] > 0) ? (bi[k] + 1) * BLOCK_W
+                                   :  bi[k]      * BLOCK_W;
+    tMax[k]   = t_near + (boundary - entry[k]) * inv_dir[k];
+    tDelta[k] = fabsf(BLOCK_W * inv_dir[k]);
+  }
+
+  float t_block = t_near;
+
+  for (int s = 0; s < GRID_DIM * 3; s++) {
+    if (bi[0] < 0 || bi[0] >= GRID_DIM ||
+        bi[1] < 0 || bi[1] >= GRID_DIM ||
+        bi[2] < 0 || bi[2] >= GRID_DIM) break;
+
+    float t_next = fminf(fminf(tMax[0], tMax[1]), fminf(tMax[2], t_far));
+
+    int idx = (bi[0] * GRID_DIM + bi[1]) * GRID_DIM + bi[2];
+    int off = block_offset[idx];
+
+    if (off >= 0) {
+      float ve[3];
+      for (int k = 0; k < 3; k++)
+        ve[k] = fmaxf(0.0f, fminf(origin[k] + t_block * dir[k], 1.0f - 1e-6f));
+
+      float bo[3] = { bi[0] * BLOCK_W, bi[1] * BLOCK_W, bi[2] * BLOCK_W };
+      int   vi[3];
+      float vtMax[3], vtDelta[3];
+      for (int k = 0; k < 3; k++) {
+        float local = (ve[k] - bo[k]) / VOXEL_SIZE;
+        vi[k] = min(LEAF_DIM - 1, max(0, (int)local));
+        float vb = (step[k] > 0) ? (vi[k] + 1) * VOXEL_SIZE + bo[k]
+                                 :  vi[k]      * VOXEL_SIZE + bo[k];
+        vtMax[k]   = t_block + (vb - ve[k]) * inv_dir[k];
+        vtDelta[k] = fabsf(VOXEL_SIZE * inv_dir[k]);
+      }
+
+      int gv[3] = { bi[0] * LEAF_DIM + vi[0],
+                     bi[1] * LEAF_DIM + vi[1],
+                     bi[2] * LEAF_DIM + vi[2] };
+
+      const float* leaf_base = leaf_data + (size_t)off * LEAF_VOXELS;
+      float prev   = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+      float prev_t = t_block;
+
+      for (int vs = 0; vs < LEAF_DIM * 3; vs++) {
+        float cur_t;
+        if (vtMax[0] <= vtMax[1] && vtMax[0] <= vtMax[2]) {
+          cur_t = vtMax[0]; vi[0] += step[0]; gv[0] += step[0];
+          vtMax[0] += vtDelta[0];
+        } else if (vtMax[1] <= vtMax[2]) {
+          cur_t = vtMax[1]; vi[1] += step[1]; gv[1] += step[1];
+          vtMax[1] += vtDelta[1];
+        } else {
+          cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
+          vtMax[2] += vtDelta[2];
+        }
+        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+            vi[1] < 0 || vi[1] >= LEAF_DIM ||
+            vi[2] < 0 || vi[2] >= LEAF_DIM ||
+            cur_t > t_next) break;
+
+        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+
+        if (prev > 0.0f && cur <= 0.0f) {
+          float alpha = prev / (prev - cur);
+          *hit_t = prev_t + alpha * (cur_t - prev_t);
+
+          float nx = d_lookup_tsdf(block_offset, leaf_data, gv[0]+1, gv[1], gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0]-1, gv[1], gv[2]);
+          float ny = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]+1, gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]-1, gv[2]);
+          float nz = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]+1)
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]-1);
+          float nn2 = nx*nx + ny*ny + nz*nz;
+          if (nn2 > 1e-12f) { float inv_nn = rsqrtf(nn2); nx *= inv_nn; ny *= inv_nn; nz *= inv_nn; }
+          else              { nx = 0; ny = 1; nz = 0; }
+          hit_normal[0] = nx; hit_normal[1] = ny; hit_normal[2] = nz;
+          return true;
+        }
+        prev   = cur;
+        prev_t = cur_t;
+      }
+    }
+
+    t_block = t_next;
+    if      (tMax[0] <= tMax[1] && tMax[0] <= tMax[2]) { bi[0] += step[0]; tMax[0] += tDelta[0]; }
+    else if (tMax[1] <= tMax[2])                       { bi[1] += step[1]; tMax[1] += tDelta[1]; }
+    else                                               { bi[2] += step[2]; tMax[2] += tDelta[2]; }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// kernel
+// ---------------------------------------------------------------------------
+
+// Per-pixel raycast kernel. Each thread generates a primary ray for its
+// pixel, traces it through the sparse volume, and writes RGB shading
+// (Lambertian with a fixed directional light) plus the hit distance
+// into the 4-channel output image.
+__global__
+void raycast_kernel(Camera cam,
+                    const int* __restrict__ block_offset,
+                    const float* __restrict__ leaf_data,
+                    float* __restrict__ image)
+{
+  int px = blockIdx.x * blockDim.x + threadIdx.x;
+  int py = blockIdx.y * blockDim.y + threadIdx.y;
+  if (px >= cam.width || py >= cam.height) return;
+
+  float origin[3], dir[3];
+  d_generate_ray(cam, px, py, origin, dir);
+
+  float ht, hn[3];
+  size_t o = 4 * ((size_t)py * cam.width + px);
+
+  if (d_cast_ray(origin, dir, block_offset, leaf_data, &ht, hn)) {
+    const float light[3] = { 0.57735f, 0.57735f, 0.57735f };
+    float ndotl = hn[0]*light[0] + hn[1]*light[1] + hn[2]*light[2];
+    float shade = 0.2f + 0.8f * fmaxf(0.0f, ndotl);
+    image[o+0] = shade; image[o+1] = shade;
+    image[o+2] = shade; image[o+3] = ht;
+  } else {
+    image[o+0] = BG_COLOR; image[o+1] = BG_COLOR;
+    image[o+2] = BG_COLOR; image[o+3] = 0.0f;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+  int num_spheres = 12, width = 1280, height = 720, reps = 100;
+  if (argc > 1) num_spheres = atoi(argv[1]);
+  if (argc > 2) width       = atoi(argv[2]);
+  if (argc > 3) height      = atoi(argv[3]);
+  if (argc > 4) reps        = atoi(argv[4]);
+  if (num_spheres > MAX_SPHERES) num_spheres = MAX_SPHERES;
+  if (num_spheres <= 0 || width <= 0 || height <= 0 || reps <= 0) {
+    fprintf(stderr, "Spheres, width, height, and reps must all be positive\n");
+    return 1;
+  }
+
+  printf("Spheres=%d  Image=%dx%d  Reps=%d\n", num_spheres, width, height, reps);
+
+  Sphere spheres[MAX_SPHERES];
+  generate_spheres(spheres, num_spheres);
+
+  SparseVolume vol;
+  build_volume(vol, spheres, num_spheres);
+
+  Camera cam;
+  setup_camera(width, height, cam);
+
+  const size_t npix = (size_t)width * height;
+
+  // host reference
+  std::vector<float> ref(4 * npix, 0.0f);
+  reference_render(cam, vol.block_offset, vol.leaf_data.data(), ref.data());
+
+  int ref_hits = 0;
+  for (size_t i = 0; i < npix; i++)
+    if (ref[4 * i + 3] > 0.0f) ref_hits++;
+  printf("Reference: %d / %zu pixels hit a surface\n", ref_hits, npix);
+
+  // device allocation
+  int   *d_block;
+  float *d_leaf, *d_image;
+  CHECK(cudaMalloc(&d_block, sizeof(int)   * GRID_BLOCKS));
+  CHECK(cudaMalloc(&d_leaf,  sizeof(float) * vol.num_active * LEAF_VOXELS));
+  CHECK(cudaMalloc(&d_image, sizeof(float) * 4 * npix));
+
+  CHECK(cudaMemcpy(d_block, vol.block_offset, sizeof(int) * GRID_BLOCKS,
+                   cudaMemcpyHostToDevice));
+  CHECK(cudaMemcpy(d_leaf, vol.leaf_data.data(),
+                   sizeof(float) * vol.num_active * LEAF_VOXELS,
+                   cudaMemcpyHostToDevice));
+
+  dim3 threads(BLOCK_X, BLOCK_Y);
+  dim3 blocks((width  + BLOCK_X - 1) / BLOCK_X,
+              (height + BLOCK_Y - 1) / BLOCK_Y);
+
+  // warmup
+  for (int r = 0; r < reps; r++)
+    raycast_kernel<<<blocks, threads>>>(cam, d_block, d_leaf, d_image);
+  CHECK(cudaGetLastError());
+  CHECK(cudaDeviceSynchronize());
+
+  // verify
+  std::vector<float> gpu(4 * npix);
+  CHECK(cudaMemcpy(gpu.data(), d_image, sizeof(float) * 4 * npix,
+                   cudaMemcpyDeviceToHost));
+
+  int mismatches = 0;
+  for (size_t i = 0; i < npix; i++) {
+    bool pixel_mismatch = false;
+    for (int c = 0; c < 4; c++)
+      pixel_mismatch |= !close_enough(gpu[4 * i + c], ref[4 * i + c], 1e-2f);
+    mismatches += pixel_mismatch;
+  }
+
+  // A handful of grazing rays may disagree on which side of a zero crossing
+  // they land due to FP evaluation order differences between host and device.
+  const int allowed = (int)(npix * 1e-4) + 1;
+  bool pass = (mismatches <= allowed);
+  printf("Raycast: %s\n", pass ? "PASS" : "FAIL");
+  if (mismatches > 0)
+    printf("  %d / %zu pixels differ (allowed %d)\n", mismatches, npix, allowed);
+
+  auto t0 = std::chrono::high_resolution_clock::now();
+  for (int r = 0; r < reps; r++)
+    raycast_kernel<<<blocks, threads>>>(cam, d_block, d_leaf, d_image);
+  CHECK(cudaDeviceSynchronize());
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+  printf("Average Raycast time: %.3f ms\n", ms / reps);
+
+  CHECK(cudaFree(d_block));
+  CHECK(cudaFree(d_leaf));
+  CHECK(cudaFree(d_image));
+
+  return 0;
+}

--- a/src/svt-cuda/main.cu
+++ b/src/svt-cuda/main.cu
@@ -17,10 +17,6 @@
     }                                                                    \
   } while (0)
 
-// ---------------------------------------------------------------------------
-// device helpers (same algorithms as reference.h, adapted for CUDA)
-// ---------------------------------------------------------------------------
-
 // Generate a primary ray for pixel (px, py) from the camera.
 // Computes the ray origin (camera eye) and a normalized direction vector
 // using the camera's right/up/forward basis and field-of-view scale.
@@ -171,12 +167,19 @@ bool d_cast_ray(const float* origin, const float* dir,
           cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
           vtMax[2] += vtDelta[2];
         }
-        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+        const bool left_leaf =
+            vi[0] < 0 || vi[0] >= LEAF_DIM ||
             vi[1] < 0 || vi[1] >= LEAF_DIM ||
-            vi[2] < 0 || vi[2] >= LEAF_DIM ||
-            cur_t > t_next) break;
+            vi[2] < 0 || vi[2] >= LEAF_DIM;
 
-        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+        // When the fine DDA steps out of the current leaf, gv[] already
+        // holds the global coordinate of the neighboring voxel. Sample it
+        // through the global lookup (which transparently resolves the
+        // neighboring block/leaf) so a surface crossing that straddles the
+        // leaf boundary is not silently discarded.
+        float cur = left_leaf
+            ? d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2])
+            : leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
 
         if (prev > 0.0f && cur <= 0.0f) {
           float alpha = prev / (prev - cur);
@@ -196,6 +199,8 @@ bool d_cast_ray(const float* origin, const float* dir,
         }
         prev   = cur;
         prev_t = cur_t;
+
+        if (left_leaf || cur_t > t_next) break;
       }
     }
 

--- a/src/svt-cuda/reference.h
+++ b/src/svt-cuda/reference.h
@@ -353,13 +353,17 @@ static bool cast_ray(const float* origin, const float* dir,
           cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
           vtMax[2] += vtDelta[2];
         }
-        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+        const bool left_leaf =
+            vi[0] < 0 || vi[0] >= LEAF_DIM ||
             vi[1] < 0 || vi[1] >= LEAF_DIM ||
-            vi[2] < 0 || vi[2] >= LEAF_DIM ||
-            cur_t > t_next) break;
+            vi[2] < 0 || vi[2] >= LEAF_DIM;
 
-        float cur = lookup_tsdf(block_offset, leaf_data,
-                                gv[0], gv[1], gv[2]);
+        // When the fine DDA steps out of the current leaf, gv[] already
+        // holds the global coordinate of the neighboring voxel. Sample it
+        // through the global lookup (which transparently resolves the
+        // neighboring block/leaf) so a surface crossing that straddles the
+        // leaf boundary is not silently discarded.
+        float cur = lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]);
 
         if (prev > 0.0f && cur <= 0.0f) {
           float alpha = prev / (prev - cur);
@@ -379,6 +383,8 @@ static bool cast_ray(const float* origin, const float* dir,
         }
         prev   = cur;
         prev_t = cur_t;
+
+        if (left_leaf || cur_t > t_next) break;
       }
     }
 

--- a/src/svt-cuda/reference.h
+++ b/src/svt-cuda/reference.h
@@ -1,0 +1,437 @@
+#ifndef REFERENCE_H
+#define REFERENCE_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <float.h>
+#include <algorithm>
+#include <vector>
+
+// Sparse-volume ray casting benchmark capturing the hierarchical traversal
+// and irregular memory-access patterns of NanoVDB-based TSDF renderers
+// (https://github.com/AcademySoftwareFoundation/openvdb/tree/master/nanovdb).
+//
+// The volume is a two-level sparse grid whose blocks are traversed with a 3-D
+// DDA at the block level and a fine-grained DDA at the voxel level inside each
+// active block.  The TSDF is procedurally generated from a union of spheres so
+// the benchmark is self-contained and has no external data dependencies.
+//
+// Reference application: slim-vdb
+// (https://github.com/umfieldrobotics/slim-vdb), which ray-casts NanoVDB
+// grids for semantic 3-D mapping in field robotics.
+
+// Tile size for GPU kernel launch
+#define BLOCK_X 16
+#define BLOCK_Y 16
+
+// Leaf (block) dimensions: 8^3 voxels per leaf
+#define LEAF_LOG2   3
+#define LEAF_DIM    (1 << LEAF_LOG2)
+#define LEAF_MASK   (LEAF_DIM - 1)
+#define LEAF_VOXELS (LEAF_DIM * LEAF_DIM * LEAF_DIM)
+
+// Coarse grid of blocks: 64^3
+#define GRID_DIM    64
+#define GRID_BLOCKS (GRID_DIM * GRID_DIM * GRID_DIM)
+
+// Total voxel resolution: 512^3
+#define VOXEL_DIM   (GRID_DIM * LEAF_DIM)
+#define VOXEL_SIZE  (1.0f / VOXEL_DIM)
+#define BLOCK_W     (LEAF_DIM * VOXEL_SIZE)
+
+// TSDF truncation distance (in world coordinates)
+#define TRUNC_DIST  (4.0f * VOXEL_SIZE)
+
+#define MAX_SPHERES 32
+#define BG_COLOR    0.1f
+
+struct Camera {
+  float eye[3];
+  float right[3];
+  float up[3];
+  float forward[3];
+  float fov_scale;
+  float inv_width, inv_height;
+  int   width, height;
+};
+
+struct Sphere {
+  float cx, cy, cz, r;
+};
+
+struct SparseVolume {
+  int   block_offset[GRID_BLOCKS];
+  std::vector<float> leaf_data;
+  int   num_active;
+};
+
+// ---------------------------------------------------------------------------
+// deterministic RNG (identical to the one in gsplat4d)
+// ---------------------------------------------------------------------------
+
+static inline unsigned rng_next(unsigned& state)
+{
+  state ^= state << 13;
+  state ^= state >> 17;
+  state ^= state << 5;
+  return state;
+}
+
+static inline float rng_uniform(unsigned& state)
+{
+  return (rng_next(state) >> 8) * (1.0f / 16777216.0f);
+}
+
+// ---------------------------------------------------------------------------
+// scene generation
+// ---------------------------------------------------------------------------
+
+static void generate_spheres(Sphere* spheres, int num_spheres)
+{
+  unsigned state = 42u;
+  for (int i = 0; i < num_spheres; i++) {
+    spheres[i].cx = 0.15f + 0.7f * rng_uniform(state);
+    spheres[i].cy = 0.15f + 0.7f * rng_uniform(state);
+    spheres[i].cz = 0.15f + 0.7f * rng_uniform(state);
+    spheres[i].r  = 0.05f + 0.12f * rng_uniform(state);
+  }
+}
+
+static inline float sphere_sdf(float x, float y, float z, const Sphere& s)
+{
+  float dx = x - s.cx, dy = y - s.cy, dz = z - s.cz;
+  return sqrtf(dx * dx + dy * dy + dz * dz) - s.r;
+}
+
+static inline float scene_sdf(float x, float y, float z,
+                               const Sphere* spheres, int num_spheres)
+{
+  float d = FLT_MAX;
+  for (int i = 0; i < num_spheres; i++)
+    d = std::min(d, sphere_sdf(x, y, z, spheres[i]));
+  return d;
+}
+
+static void build_volume(SparseVolume& vol,
+                          const Sphere* spheres, int num_spheres)
+{
+  vol.num_active = 0;
+
+  const float block_diag = sqrtf(3.0f) * 0.5f * BLOCK_W;
+
+  for (int bx = 0; bx < GRID_DIM; bx++)
+    for (int by = 0; by < GRID_DIM; by++)
+      for (int bz = 0; bz < GRID_DIM; bz++) {
+        int bi = (bx * GRID_DIM + by) * GRID_DIM + bz;
+
+        float cx = (bx + 0.5f) * BLOCK_W;
+        float cy = (by + 0.5f) * BLOCK_W;
+        float cz = (bz + 0.5f) * BLOCK_W;
+
+        bool active = false;
+        for (int s = 0; s < num_spheres && !active; s++)
+          if (fabsf(sphere_sdf(cx, cy, cz, spheres[s])) < TRUNC_DIST + block_diag)
+            active = true;
+
+        vol.block_offset[bi] = active ? vol.num_active++ : -1;
+      }
+
+  vol.leaf_data.resize((size_t)vol.num_active * LEAF_VOXELS);
+
+  for (int bx = 0; bx < GRID_DIM; bx++)
+    for (int by = 0; by < GRID_DIM; by++)
+      for (int bz = 0; bz < GRID_DIM; bz++) {
+        int bi  = (bx * GRID_DIM + by) * GRID_DIM + bz;
+        int off = vol.block_offset[bi];
+        if (off < 0) continue;
+
+        float bx0 = bx * BLOCK_W, by0 = by * BLOCK_W, bz0 = bz * BLOCK_W;
+
+        for (int lx = 0; lx < LEAF_DIM; lx++)
+          for (int ly = 0; ly < LEAF_DIM; ly++)
+            for (int lz = 0; lz < LEAF_DIM; lz++) {
+              float x = bx0 + (lx + 0.5f) * VOXEL_SIZE;
+              float y = by0 + (ly + 0.5f) * VOXEL_SIZE;
+              float z = bz0 + (lz + 0.5f) * VOXEL_SIZE;
+
+              float d = scene_sdf(x, y, z, spheres, num_spheres);
+              d = std::max(-1.0f, std::min(1.0f, d / TRUNC_DIST));
+
+              int li = (lx * LEAF_DIM + ly) * LEAF_DIM + lz;
+              vol.leaf_data[(size_t)off * LEAF_VOXELS + li] = d;
+            }
+      }
+
+  printf("Sparse volume: %d active blocks out of %d (%.1f%% occupancy)\n",
+         vol.num_active, GRID_BLOCKS,
+         100.0f * vol.num_active / GRID_BLOCKS);
+}
+
+// ---------------------------------------------------------------------------
+// camera
+// ---------------------------------------------------------------------------
+
+static void setup_camera(int width, int height, Camera& cam)
+{
+  const float target[3] = { 0.5f, 0.5f, 0.5f };
+  const float yaw = 0.4f, pitch = 0.3f, dist = 2.0f;
+
+  float f[3] = { sinf(yaw) * cosf(pitch), sinf(pitch),
+                 cosf(yaw) * cosf(pitch) };
+  for (int k = 0; k < 3; k++) cam.eye[k] = target[k] - dist * f[k];
+
+  float fn = sqrtf(f[0] * f[0] + f[1] * f[1] + f[2] * f[2]);
+  for (int k = 0; k < 3; k++) cam.forward[k] = f[k] / fn;
+
+  const float up_w[3] = { 0.0f, 1.0f, 0.0f };
+  cam.right[0] = cam.forward[1] * up_w[2] - cam.forward[2] * up_w[1];
+  cam.right[1] = cam.forward[2] * up_w[0] - cam.forward[0] * up_w[2];
+  cam.right[2] = cam.forward[0] * up_w[1] - cam.forward[1] * up_w[0];
+  float rn = sqrtf(cam.right[0] * cam.right[0] + cam.right[1] * cam.right[1] +
+                   cam.right[2] * cam.right[2]);
+  for (int k = 0; k < 3; k++) cam.right[k] /= rn;
+
+  cam.up[0] = cam.right[1] * cam.forward[2] - cam.right[2] * cam.forward[1];
+  cam.up[1] = cam.right[2] * cam.forward[0] - cam.right[0] * cam.forward[2];
+  cam.up[2] = cam.right[0] * cam.forward[1] - cam.right[1] * cam.forward[0];
+
+  cam.fov_scale = tanf(45.0f * 0.5f * 3.14159265f / 180.0f);
+  cam.inv_width = 1.0f / width;
+  cam.inv_height = 1.0f / height;
+  cam.width = width;
+  cam.height = height;
+}
+
+// ---------------------------------------------------------------------------
+// ray generation and intersection helpers
+// ---------------------------------------------------------------------------
+
+static inline void generate_ray(const Camera& cam, int px, int py,
+                                 float* origin, float* dir)
+{
+  const float aspect = (float)cam.width * cam.inv_height;
+  const float u = (2.0f * (px + 0.5f) * cam.inv_width  - 1.0f) *
+                  cam.fov_scale * aspect;
+  const float v = (2.0f * (py + 0.5f) * cam.inv_height - 1.0f) *
+                  cam.fov_scale;
+
+  for (int k = 0; k < 3; k++) {
+    origin[k] = cam.eye[k];
+    dir[k] = u * cam.right[k] + v * cam.up[k] + cam.forward[k];
+  }
+  const float dn = sqrtf(dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]);
+  for (int k = 0; k < 3; k++) dir[k] /= dn;
+}
+
+static inline bool ray_box(const float* origin, const float* dir,
+                            float* t_near, float* t_far)
+{
+  float tmin = -FLT_MAX, tmax = FLT_MAX;
+  for (int k = 0; k < 3; k++) {
+    if (fabsf(dir[k]) < 1e-8f) {
+      if (origin[k] < 0.0f || origin[k] > 1.0f) return false;
+    } else {
+      float inv = 1.0f / dir[k];
+      float t1 = -origin[k] * inv;
+      float t2 = (1.0f - origin[k]) * inv;
+      if (t1 > t2) { float tmp = t1; t1 = t2; t2 = tmp; }
+      tmin = std::max(tmin, t1);
+      tmax = std::min(tmax, t2);
+    }
+  }
+  *t_near = std::max(tmin, 0.0f);
+  *t_far  = tmax;
+  return *t_near < *t_far;
+}
+
+// ---------------------------------------------------------------------------
+// TSDF lookup in the sparse volume
+// ---------------------------------------------------------------------------
+
+static inline float lookup_tsdf(const int* block_offset,
+                                 const float* leaf_data,
+                                 int vx, int vy, int vz)
+{
+  if (vx < 0 || vx >= VOXEL_DIM ||
+      vy < 0 || vy >= VOXEL_DIM ||
+      vz < 0 || vz >= VOXEL_DIM) return 1.0f;
+
+  int bx = vx >> LEAF_LOG2, by = vy >> LEAF_LOG2, bz = vz >> LEAF_LOG2;
+  int bi = (bx * GRID_DIM + by) * GRID_DIM + bz;
+  int off = block_offset[bi];
+  if (off < 0) return 1.0f;
+
+  int lx = vx & LEAF_MASK, ly = vy & LEAF_MASK, lz = vz & LEAF_MASK;
+  return leaf_data[(size_t)off * LEAF_VOXELS +
+                   (lx * LEAF_DIM + ly) * LEAF_DIM + lz];
+}
+
+// ---------------------------------------------------------------------------
+// two-level DDA ray caster (reference)
+// ---------------------------------------------------------------------------
+
+static bool cast_ray(const float* origin, const float* dir,
+                     const int* block_offset, const float* leaf_data,
+                     float* hit_t, float* hit_normal)
+{
+  float t_near, t_far;
+  if (!ray_box(origin, dir, &t_near, &t_far)) return false;
+
+  float inv_dir[3];
+  int   step[3];
+  for (int k = 0; k < 3; k++) {
+    inv_dir[k] = (fabsf(dir[k]) > 1e-8f) ? (1.0f / dir[k]) : 1e8f;
+    step[k]    = (dir[k] >= 0.0f) ? 1 : -1;
+  }
+
+  float entry[3];
+  for (int k = 0; k < 3; k++)
+    entry[k] = std::max(0.0f, std::min(origin[k] + t_near * dir[k],
+                                       1.0f - 1e-6f));
+
+  int   bi[3];
+  float tMax[3], tDelta[3];
+  for (int k = 0; k < 3; k++) {
+    bi[k] = std::min(GRID_DIM - 1, std::max(0, (int)(entry[k] / BLOCK_W)));
+    float boundary = (step[k] > 0)
+        ? (bi[k] + 1) * BLOCK_W
+        :  bi[k]      * BLOCK_W;
+    tMax[k]  = t_near + (boundary - entry[k]) * inv_dir[k];
+    tDelta[k] = fabsf(BLOCK_W * inv_dir[k]);
+  }
+
+  float t_block = t_near;
+
+  for (int s = 0; s < GRID_DIM * 3; s++) {
+    if (bi[0] < 0 || bi[0] >= GRID_DIM ||
+        bi[1] < 0 || bi[1] >= GRID_DIM ||
+        bi[2] < 0 || bi[2] >= GRID_DIM) break;
+
+    float t_next = std::min({ tMax[0], tMax[1], tMax[2], t_far });
+
+    int idx = (bi[0] * GRID_DIM + bi[1]) * GRID_DIM + bi[2];
+    int off = block_offset[idx];
+
+    if (off >= 0) {
+      // fine-grained DDA inside the active block
+      float ve[3];
+      for (int k = 0; k < 3; k++)
+        ve[k] = std::max(0.0f, std::min(origin[k] + t_block * dir[k],
+                                        1.0f - 1e-6f));
+
+      float bo[3] = { bi[0] * BLOCK_W, bi[1] * BLOCK_W, bi[2] * BLOCK_W };
+
+      int   vi[3];
+      float vtMax[3], vtDelta[3];
+      for (int k = 0; k < 3; k++) {
+        float local = (ve[k] - bo[k]) / VOXEL_SIZE;
+        vi[k] = std::min(LEAF_DIM - 1, std::max(0, (int)local));
+        float vb = (step[k] > 0) ? (vi[k] + 1) * VOXEL_SIZE + bo[k]
+                                 :  vi[k]      * VOXEL_SIZE + bo[k];
+        vtMax[k]   = t_block + (vb - ve[k]) * inv_dir[k];
+        vtDelta[k] = fabsf(VOXEL_SIZE * inv_dir[k]);
+      }
+
+      int gv[3] = { bi[0] * LEAF_DIM + vi[0],
+                     bi[1] * LEAF_DIM + vi[1],
+                     bi[2] * LEAF_DIM + vi[2] };
+
+      float prev = lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]);
+      float prev_t = t_block;
+
+      for (int vs = 0; vs < LEAF_DIM * 3; vs++) {
+        float cur_t;
+        if (vtMax[0] <= vtMax[1] && vtMax[0] <= vtMax[2]) {
+          cur_t = vtMax[0]; vi[0] += step[0]; gv[0] += step[0];
+          vtMax[0] += vtDelta[0];
+        } else if (vtMax[1] <= vtMax[2]) {
+          cur_t = vtMax[1]; vi[1] += step[1]; gv[1] += step[1];
+          vtMax[1] += vtDelta[1];
+        } else {
+          cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
+          vtMax[2] += vtDelta[2];
+        }
+        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+            vi[1] < 0 || vi[1] >= LEAF_DIM ||
+            vi[2] < 0 || vi[2] >= LEAF_DIM ||
+            cur_t > t_next) break;
+
+        float cur = lookup_tsdf(block_offset, leaf_data,
+                                gv[0], gv[1], gv[2]);
+
+        if (prev > 0.0f && cur <= 0.0f) {
+          float alpha = prev / (prev - cur);
+          *hit_t = prev_t + alpha * (cur_t - prev_t);
+
+          float nx = lookup_tsdf(block_offset, leaf_data, gv[0]+1, gv[1], gv[2])
+                   - lookup_tsdf(block_offset, leaf_data, gv[0]-1, gv[1], gv[2]);
+          float ny = lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]+1, gv[2])
+                   - lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]-1, gv[2]);
+          float nz = lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]+1)
+                   - lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]-1);
+          float nn = sqrtf(nx * nx + ny * ny + nz * nz);
+          if (nn > 1e-6f) { nx /= nn; ny /= nn; nz /= nn; }
+          else            { nx = 0; ny = 1; nz = 0; }
+          hit_normal[0] = nx; hit_normal[1] = ny; hit_normal[2] = nz;
+          return true;
+        }
+        prev   = cur;
+        prev_t = cur_t;
+      }
+    }
+
+    t_block = t_next;
+    if      (tMax[0] <= tMax[1] && tMax[0] <= tMax[2]) { bi[0] += step[0]; tMax[0] += tDelta[0]; }
+    else if (tMax[1] <= tMax[2])                       { bi[1] += step[1]; tMax[1] += tDelta[1]; }
+    else                                               { bi[2] += step[2]; tMax[2] += tDelta[2]; }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// reference renderer
+// ---------------------------------------------------------------------------
+
+static void reference_render(const Camera& cam,
+                              const int* block_offset,
+                              const float* leaf_data,
+                              float* image)
+{
+  const float light[3] = { 0.57735f, 0.57735f, 0.57735f };
+
+  for (int py = 0; py < cam.height; py++)
+    for (int px = 0; px < cam.width; px++) {
+      float origin[3], dir[3];
+      generate_ray(cam, px, py, origin, dir);
+
+      float ht, hn[3];
+      size_t o = 4 * ((size_t)py * cam.width + px);
+
+      if (cast_ray(origin, dir, block_offset, leaf_data, &ht, hn)) {
+        float ndotl = hn[0] * light[0] + hn[1] * light[1] + hn[2] * light[2];
+        float shade = 0.2f + 0.8f * std::max(0.0f, ndotl);
+        image[o + 0] = shade;
+        image[o + 1] = shade;
+        image[o + 2] = shade;
+        image[o + 3] = ht;
+      } else {
+        image[o + 0] = BG_COLOR;
+        image[o + 1] = BG_COLOR;
+        image[o + 2] = BG_COLOR;
+        image[o + 3] = 0.0f;
+      }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// verification
+// ---------------------------------------------------------------------------
+
+static bool close_enough(float a, float b, float tol)
+{
+  return fabsf(a - b) <= tol * (1.0f + fabsf(b));
+}
+
+#endif // REFERENCE_H

--- a/src/svt-hip/CMakeLists.txt
+++ b/src/svt-hip/CMakeLists.txt
@@ -1,0 +1,11 @@
+# svt-hip/CMakeLists.txt
+
+add_hecbench_benchmark(
+    NAME svt
+    MODEL hip
+    SOURCES main.cu
+    CATEGORIES simulation
+    TEST_ARGS 12 1280 720 100
+    TEST_REGEX "Raycast: PASS"
+    TEST_TIMEOUT 300
+)

--- a/src/svt-hip/Makefile
+++ b/src/svt-hip/Makefile
@@ -52,4 +52,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) 12 1280 720 100
+	$(LAUNCHER) ./$(program) 12 1280 720 1000

--- a/src/svt-hip/Makefile
+++ b/src/svt-hip/Makefile
@@ -1,0 +1,55 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+# Compiler can be set below, or via environment variable
+CC        = hipcc
+OPTIMIZE  = yes
+DEBUG     = no
+LAUNCHER  ?=
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = main
+
+source = main.cu
+
+obj = $(source:.cu=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../svt-cuda
+
+# Linker Flags
+LDFLAGS =
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g -DDEBUG
+  LDFLAGS  += -g
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) Makefile
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cu ../svt-cuda/reference.h Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+run: $(program)
+	$(LAUNCHER) ./$(program) 12 1280 720 100

--- a/src/svt-hip/main.cu
+++ b/src/svt-hip/main.cu
@@ -156,12 +156,19 @@ bool d_cast_ray(const float* origin, const float* dir,
           cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
           vtMax[2] += vtDelta[2];
         }
-        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+        const bool left_leaf =
+            vi[0] < 0 || vi[0] >= LEAF_DIM ||
             vi[1] < 0 || vi[1] >= LEAF_DIM ||
-            vi[2] < 0 || vi[2] >= LEAF_DIM ||
-            cur_t > t_next) break;
+            vi[2] < 0 || vi[2] >= LEAF_DIM;
 
-        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+        // When the fine DDA steps out of the current leaf, gv[] already
+        // holds the global coordinate of the neighboring voxel. Sample it
+        // through the global lookup (which transparently resolves the
+        // neighboring block/leaf) so a surface crossing that straddles the
+        // leaf boundary is not silently discarded.
+        float cur = left_leaf
+            ? d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2])
+            : leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
 
         if (prev > 0.0f && cur <= 0.0f) {
           float alpha = prev / (prev - cur);
@@ -181,6 +188,8 @@ bool d_cast_ray(const float* origin, const float* dir,
         }
         prev   = cur;
         prev_t = cur_t;
+
+        if (left_leaf || cur_t > t_next) break;
       }
     }
 

--- a/src/svt-hip/main.cu
+++ b/src/svt-hip/main.cu
@@ -1,0 +1,321 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <chrono>
+#include <vector>
+#include <hip/hip_runtime.h>
+
+#include "reference.h"
+
+#define CHECK(call)                                                      \
+  do {                                                                   \
+    hipError_t err = (call);                                             \
+    if (err != hipSuccess) {                                             \
+      fprintf(stderr, "HIP error at %s:%d: %s\n",                       \
+              __FILE__, __LINE__, hipGetErrorString(err));               \
+      exit(EXIT_FAILURE);                                                \
+    }                                                                    \
+  } while (0)
+
+// ---------------------------------------------------------------------------
+// device helpers
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__
+void d_generate_ray(const Camera cam, int px, int py,
+                    float* origin, float* dir)
+{
+  const float aspect = (float)cam.width * cam.inv_height;
+  const float u = (2.0f * (px + 0.5f) * cam.inv_width  - 1.0f) *
+                  cam.fov_scale * aspect;
+  const float v = (2.0f * (py + 0.5f) * cam.inv_height - 1.0f) *
+                  cam.fov_scale;
+  for (int k = 0; k < 3; k++) {
+    origin[k] = cam.eye[k];
+    dir[k] = u * cam.right[k] + v * cam.up[k] + cam.forward[k];
+  }
+  float inv_dn = rsqrtf(dir[0]*dir[0] + dir[1]*dir[1] + dir[2]*dir[2]);
+  for (int k = 0; k < 3; k++) dir[k] *= inv_dn;
+}
+
+__device__ __forceinline__
+bool d_ray_box(const float* origin, const float* dir,
+               float* t_near, float* t_far)
+{
+  float tmin = -1e30f, tmax = 1e30f;
+  for (int k = 0; k < 3; k++) {
+    if (fabsf(dir[k]) < 1e-8f) {
+      if (origin[k] < 0.0f || origin[k] > 1.0f) return false;
+    } else {
+      float inv = 1.0f / dir[k];
+      float t1 = -origin[k] * inv;
+      float t2 = (1.0f - origin[k]) * inv;
+      if (t1 > t2) { float tmp = t1; t1 = t2; t2 = tmp; }
+      tmin = fmaxf(tmin, t1);
+      tmax = fminf(tmax, t2);
+    }
+  }
+  *t_near = fmaxf(tmin, 0.0f);
+  *t_far  = tmax;
+  return *t_near < *t_far;
+}
+
+__device__ __forceinline__
+float d_lookup_tsdf(const int* block_offset, const float* leaf_data,
+                    int vx, int vy, int vz)
+{
+  if (vx < 0 || vx >= VOXEL_DIM ||
+      vy < 0 || vy >= VOXEL_DIM ||
+      vz < 0 || vz >= VOXEL_DIM) return 1.0f;
+
+  int bx = vx >> LEAF_LOG2, by = vy >> LEAF_LOG2, bz = vz >> LEAF_LOG2;
+  int bi = (bx * GRID_DIM + by) * GRID_DIM + bz;
+  int off = block_offset[bi];
+  if (off < 0) return 1.0f;
+
+  int lx = vx & LEAF_MASK, ly = vy & LEAF_MASK, lz = vz & LEAF_MASK;
+  return leaf_data[(size_t)off * LEAF_VOXELS +
+                   (lx * LEAF_DIM + ly) * LEAF_DIM + lz];
+}
+
+__device__
+bool d_cast_ray(const float* origin, const float* dir,
+                const int* block_offset, const float* leaf_data,
+                float* hit_t, float* hit_normal)
+{
+  float t_near, t_far;
+  if (!d_ray_box(origin, dir, &t_near, &t_far)) return false;
+
+  float inv_dir[3];
+  int   step[3];
+  for (int k = 0; k < 3; k++) {
+    inv_dir[k] = (fabsf(dir[k]) > 1e-8f) ? (1.0f / dir[k]) : 1e8f;
+    step[k]    = (dir[k] >= 0.0f) ? 1 : -1;
+  }
+
+  float entry[3];
+  for (int k = 0; k < 3; k++)
+    entry[k] = fmaxf(0.0f, fminf(origin[k] + t_near * dir[k], 1.0f - 1e-6f));
+
+  int   bi[3];
+  float tMax[3], tDelta[3];
+  for (int k = 0; k < 3; k++) {
+    bi[k] = min(GRID_DIM - 1, max(0, (int)(entry[k] / BLOCK_W)));
+    float boundary = (step[k] > 0) ? (bi[k] + 1) * BLOCK_W
+                                   :  bi[k]      * BLOCK_W;
+    tMax[k]   = t_near + (boundary - entry[k]) * inv_dir[k];
+    tDelta[k] = fabsf(BLOCK_W * inv_dir[k]);
+  }
+
+  float t_block = t_near;
+
+  for (int s = 0; s < GRID_DIM * 3; s++) {
+    if (bi[0] < 0 || bi[0] >= GRID_DIM ||
+        bi[1] < 0 || bi[1] >= GRID_DIM ||
+        bi[2] < 0 || bi[2] >= GRID_DIM) break;
+
+    float t_next = fminf(fminf(tMax[0], tMax[1]), fminf(tMax[2], t_far));
+
+    int idx = (bi[0] * GRID_DIM + bi[1]) * GRID_DIM + bi[2];
+    int off = block_offset[idx];
+
+    if (off >= 0) {
+      float ve[3];
+      for (int k = 0; k < 3; k++)
+        ve[k] = fmaxf(0.0f, fminf(origin[k] + t_block * dir[k], 1.0f - 1e-6f));
+
+      float bo[3] = { bi[0] * BLOCK_W, bi[1] * BLOCK_W, bi[2] * BLOCK_W };
+      int   vi[3];
+      float vtMax[3], vtDelta[3];
+      for (int k = 0; k < 3; k++) {
+        float local = (ve[k] - bo[k]) / VOXEL_SIZE;
+        vi[k] = min(LEAF_DIM - 1, max(0, (int)local));
+        float vb = (step[k] > 0) ? (vi[k] + 1) * VOXEL_SIZE + bo[k]
+                                 :  vi[k]      * VOXEL_SIZE + bo[k];
+        vtMax[k]   = t_block + (vb - ve[k]) * inv_dir[k];
+        vtDelta[k] = fabsf(VOXEL_SIZE * inv_dir[k]);
+      }
+
+      int gv[3] = { bi[0] * LEAF_DIM + vi[0],
+                     bi[1] * LEAF_DIM + vi[1],
+                     bi[2] * LEAF_DIM + vi[2] };
+
+      const float* leaf_base = leaf_data + (size_t)off * LEAF_VOXELS;
+      float prev   = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+      float prev_t = t_block;
+
+      for (int vs = 0; vs < LEAF_DIM * 3; vs++) {
+        float cur_t;
+        if (vtMax[0] <= vtMax[1] && vtMax[0] <= vtMax[2]) {
+          cur_t = vtMax[0]; vi[0] += step[0]; gv[0] += step[0];
+          vtMax[0] += vtDelta[0];
+        } else if (vtMax[1] <= vtMax[2]) {
+          cur_t = vtMax[1]; vi[1] += step[1]; gv[1] += step[1];
+          vtMax[1] += vtDelta[1];
+        } else {
+          cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
+          vtMax[2] += vtDelta[2];
+        }
+        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+            vi[1] < 0 || vi[1] >= LEAF_DIM ||
+            vi[2] < 0 || vi[2] >= LEAF_DIM ||
+            cur_t > t_next) break;
+
+        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+
+        if (prev > 0.0f && cur <= 0.0f) {
+          float alpha = prev / (prev - cur);
+          *hit_t = prev_t + alpha * (cur_t - prev_t);
+
+          float nx = d_lookup_tsdf(block_offset, leaf_data, gv[0]+1, gv[1], gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0]-1, gv[1], gv[2]);
+          float ny = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]+1, gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]-1, gv[2]);
+          float nz = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]+1)
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]-1);
+          float nn2 = nx*nx + ny*ny + nz*nz;
+          if (nn2 > 1e-12f) { float inv_nn = rsqrtf(nn2); nx *= inv_nn; ny *= inv_nn; nz *= inv_nn; }
+          else              { nx = 0; ny = 1; nz = 0; }
+          hit_normal[0] = nx; hit_normal[1] = ny; hit_normal[2] = nz;
+          return true;
+        }
+        prev   = cur;
+        prev_t = cur_t;
+      }
+    }
+
+    t_block = t_next;
+    if      (tMax[0] <= tMax[1] && tMax[0] <= tMax[2]) { bi[0] += step[0]; tMax[0] += tDelta[0]; }
+    else if (tMax[1] <= tMax[2])                       { bi[1] += step[1]; tMax[1] += tDelta[1]; }
+    else                                               { bi[2] += step[2]; tMax[2] += tDelta[2]; }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// kernel
+// ---------------------------------------------------------------------------
+
+__global__
+void raycast_kernel(Camera cam,
+                    const int* __restrict__ block_offset,
+                    const float* __restrict__ leaf_data,
+                    float* __restrict__ image)
+{
+  int px = blockIdx.x * blockDim.x + threadIdx.x;
+  int py = blockIdx.y * blockDim.y + threadIdx.y;
+  if (px >= cam.width || py >= cam.height) return;
+
+  float origin[3], dir[3];
+  d_generate_ray(cam, px, py, origin, dir);
+
+  float ht, hn[3];
+  size_t o = 4 * ((size_t)py * cam.width + px);
+
+  if (d_cast_ray(origin, dir, block_offset, leaf_data, &ht, hn)) {
+    const float light[3] = { 0.57735f, 0.57735f, 0.57735f };
+    float ndotl = hn[0]*light[0] + hn[1]*light[1] + hn[2]*light[2];
+    float shade = 0.2f + 0.8f * fmaxf(0.0f, ndotl);
+    image[o+0] = shade; image[o+1] = shade;
+    image[o+2] = shade; image[o+3] = ht;
+  } else {
+    image[o+0] = BG_COLOR; image[o+1] = BG_COLOR;
+    image[o+2] = BG_COLOR; image[o+3] = 0.0f;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+  int num_spheres = 12, width = 1280, height = 720, reps = 100;
+  if (argc > 1) num_spheres = atoi(argv[1]);
+  if (argc > 2) width       = atoi(argv[2]);
+  if (argc > 3) height      = atoi(argv[3]);
+  if (argc > 4) reps        = atoi(argv[4]);
+  if (num_spheres > MAX_SPHERES) num_spheres = MAX_SPHERES;
+  if (num_spheres <= 0 || width <= 0 || height <= 0 || reps <= 0) {
+    fprintf(stderr, "Spheres, width, height, and reps must all be positive\n");
+    return 1;
+  }
+
+  printf("Spheres=%d  Image=%dx%d  Reps=%d\n", num_spheres, width, height, reps);
+
+  Sphere spheres[MAX_SPHERES];
+  generate_spheres(spheres, num_spheres);
+
+  SparseVolume vol;
+  build_volume(vol, spheres, num_spheres);
+
+  Camera cam;
+  setup_camera(width, height, cam);
+
+  const size_t npix = (size_t)width * height;
+
+  std::vector<float> ref(4 * npix, 0.0f);
+  reference_render(cam, vol.block_offset, vol.leaf_data.data(), ref.data());
+
+  int ref_hits = 0;
+  for (size_t i = 0; i < npix; i++)
+    if (ref[4 * i + 3] > 0.0f) ref_hits++;
+  printf("Reference: %d / %zu pixels hit a surface\n", ref_hits, npix);
+
+  int   *d_block;
+  float *d_leaf, *d_image;
+  CHECK(hipMalloc(&d_block, sizeof(int)   * GRID_BLOCKS));
+  CHECK(hipMalloc(&d_leaf,  sizeof(float) * vol.num_active * LEAF_VOXELS));
+  CHECK(hipMalloc(&d_image, sizeof(float) * 4 * npix));
+
+  CHECK(hipMemcpy(d_block, vol.block_offset, sizeof(int) * GRID_BLOCKS,
+                  hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(d_leaf, vol.leaf_data.data(),
+                  sizeof(float) * vol.num_active * LEAF_VOXELS,
+                  hipMemcpyHostToDevice));
+
+  dim3 threads(BLOCK_X, BLOCK_Y);
+  dim3 blocks((width  + BLOCK_X - 1) / BLOCK_X,
+              (height + BLOCK_Y - 1) / BLOCK_Y);
+
+  // warmup
+  for (int r = 0; r < reps; r++)
+    raycast_kernel<<<blocks, threads>>>(cam, d_block, d_leaf, d_image);
+  CHECK(hipGetLastError());
+  CHECK(hipDeviceSynchronize());
+
+  // verify
+  std::vector<float> gpu(4 * npix);
+  CHECK(hipMemcpy(gpu.data(), d_image, sizeof(float) * 4 * npix,
+                  hipMemcpyDeviceToHost));
+
+  int mismatches = 0;
+  for (size_t i = 0; i < npix; i++) {
+    bool pixel_mismatch = false;
+    for (int c = 0; c < 4; c++)
+      pixel_mismatch |= !close_enough(gpu[4 * i + c], ref[4 * i + c], 1e-2f);
+    mismatches += pixel_mismatch;
+  }
+
+  const int allowed = (int)(npix * 1e-4) + 1;
+  bool pass = (mismatches <= allowed);
+  printf("Raycast: %s\n", pass ? "PASS" : "FAIL");
+  if (mismatches > 0)
+    printf("  %d / %zu pixels differ (allowed %d)\n",
+           mismatches, npix, allowed);
+
+  auto t0 = std::chrono::high_resolution_clock::now();
+  for (int r = 0; r < reps; r++)
+    raycast_kernel<<<blocks, threads>>>(cam, d_block, d_leaf, d_image);
+  CHECK(hipDeviceSynchronize());
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+  printf("Average Raycast time: %.3f ms\n", ms / reps);
+
+  CHECK(hipFree(d_block));
+  CHECK(hipFree(d_leaf));
+  CHECK(hipFree(d_image));
+
+  return 0;
+}

--- a/src/svt-omp/CMakeLists.txt
+++ b/src/svt-omp/CMakeLists.txt
@@ -1,0 +1,11 @@
+# svt-omp/CMakeLists.txt
+
+add_hecbench_benchmark(
+    NAME svt
+    MODEL omp
+    SOURCES main.cpp
+    CATEGORIES simulation
+    TEST_ARGS 12 1280 720 100
+    TEST_REGEX "Raycast: PASS"
+    TEST_TIMEOUT 300
+)

--- a/src/svt-omp/Makefile
+++ b/src/svt-omp/Makefile
@@ -59,4 +59,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) 12 1280 720 100
+	$(LAUNCHER) ./$(program) 12 1280 720 1000

--- a/src/svt-omp/Makefile
+++ b/src/svt-omp/Makefile
@@ -1,0 +1,62 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+# Compiler can be set below, or via environment variable
+CC        = icpx
+OPTIMIZE  = yes
+DEBUG     = no
+DEVICE    = gpu
+LAUNCHER  ?=
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = main
+
+source = main.cpp
+
+obj = $(source:.cpp=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../svt-cuda
+
+# Linker Flags
+LDFLAGS =
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g
+  LDFLAGS  += -g
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+
+ifeq ($(DEVICE),gpu)
+  CFLAGS +=-fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__
+else
+  CFLAGS +=-qopenmp
+endif
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) Makefile
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cpp ../svt-cuda/reference.h Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+run: $(program)
+	$(LAUNCHER) ./$(program) 12 1280 720 100

--- a/src/svt-omp/Makefile.aomp
+++ b/src/svt-omp/Makefile.aomp
@@ -63,4 +63,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) 12 1280 720 100
+	$(LAUNCHER) ./$(program) 12 1280 720 1000

--- a/src/svt-omp/Makefile.aomp
+++ b/src/svt-omp/Makefile.aomp
@@ -1,0 +1,66 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+# Compiler can be set below, or via environment variable
+CC        = clang++
+OPTIMIZE  = yes
+DEBUG     = no
+DEVICE    = gpu
+ARCH      = gfx906
+LAUNCHER  ?=
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = main
+
+source = main.cpp
+
+obj = $(source:.cpp=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../svt-cuda
+
+# Linker Flags
+LDFLAGS =
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g
+  LDFLAGS  += -g
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+
+ifeq ($(DEVICE),gpu)
+  CFLAGS += -target x86_64-pc-linux-gnu \
+          -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa \
+          -Xopenmp-target=amdgcn-amd-amdhsa \
+          -march=$(ARCH)
+else
+  CFLAGS +=-fopenmp
+endif
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) Makefile.aomp
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cpp ../svt-cuda/reference.h Makefile.aomp
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+run: $(program)
+	$(LAUNCHER) ./$(program) 12 1280 720 100

--- a/src/svt-omp/Makefile.nvc
+++ b/src/svt-omp/Makefile.nvc
@@ -1,0 +1,63 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+# Compiler can be set below, or via environment variable
+CC        = nvc++
+OPTIMIZE  = yes
+DEBUG     = no
+DEVICE    = gpu
+SM        ?= cc70
+LAUNCHER  ?=
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = main
+
+source = main.cpp
+
+obj = $(source:.cpp=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../svt-cuda
+
+# Linker Flags
+LDFLAGS =
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS += -g
+  LDFLAGS  += -g
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+
+ifeq ($(DEVICE),gpu)
+  CFLAGS +=-Minfo -mp=gpu -gpu=$(SM)#,fastmath
+else
+  CFLAGS +=
+endif
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) Makefile.nvc
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cpp ../svt-cuda/reference.h Makefile.nvc
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+run: $(program)
+	$(LAUNCHER) ./$(program) 12 1280 720 100

--- a/src/svt-omp/Makefile.nvc
+++ b/src/svt-omp/Makefile.nvc
@@ -60,4 +60,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) 12 1280 720 100
+	$(LAUNCHER) ./$(program) 12 1280 720 1000

--- a/src/svt-omp/main.cpp
+++ b/src/svt-omp/main.cpp
@@ -1,0 +1,314 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <chrono>
+#include <vector>
+
+#include "reference.h"
+
+#pragma omp declare target
+
+static inline void d_generate_ray(const Camera& cam, int px, int py,
+                                   float* origin, float* dir)
+{
+  const float aspect = (float)cam.width * cam.inv_height;
+  const float u = (2.0f * (px + 0.5f) * cam.inv_width  - 1.0f) *
+                  cam.fov_scale * aspect;
+  const float v = (2.0f * (py + 0.5f) * cam.inv_height - 1.0f) *
+                  cam.fov_scale;
+  for (int k = 0; k < 3; k++) {
+    origin[k] = cam.eye[k];
+    dir[k] = u * cam.right[k] + v * cam.up[k] + cam.forward[k];
+  }
+  float inv_dn = 1.0f / sqrtf(dir[0]*dir[0] + dir[1]*dir[1] + dir[2]*dir[2]);
+  for (int k = 0; k < 3; k++) dir[k] *= inv_dn;
+}
+
+static inline bool d_ray_box(const float* origin, const float* dir,
+                              float* t_near, float* t_far)
+{
+  float tmin = -1e30f, tmax = 1e30f;
+  for (int k = 0; k < 3; k++) {
+    if (fabsf(dir[k]) < 1e-8f) {
+      if (origin[k] < 0.0f || origin[k] > 1.0f) return false;
+    } else {
+      float inv = 1.0f / dir[k];
+      float t1 = -origin[k] * inv;
+      float t2 = (1.0f - origin[k]) * inv;
+      if (t1 > t2) { float tmp = t1; t1 = t2; t2 = tmp; }
+      if (t1 > tmin) tmin = t1;
+      if (t2 < tmax) tmax = t2;
+    }
+  }
+  *t_near = (tmin > 0.0f) ? tmin : 0.0f;
+  *t_far  = tmax;
+  return *t_near < *t_far;
+}
+
+static inline float d_lookup_tsdf(const int* block_offset,
+                                   const float* leaf_data,
+                                   int vx, int vy, int vz)
+{
+  if (vx < 0 || vx >= VOXEL_DIM ||
+      vy < 0 || vy >= VOXEL_DIM ||
+      vz < 0 || vz >= VOXEL_DIM) return 1.0f;
+
+  int bx = vx >> LEAF_LOG2, by = vy >> LEAF_LOG2, bz = vz >> LEAF_LOG2;
+  int bi = (bx * GRID_DIM + by) * GRID_DIM + bz;
+  int off = block_offset[bi];
+  if (off < 0) return 1.0f;
+
+  int lx = vx & LEAF_MASK, ly = vy & LEAF_MASK, lz = vz & LEAF_MASK;
+  return leaf_data[(size_t)off * LEAF_VOXELS +
+                   (lx * LEAF_DIM + ly) * LEAF_DIM + lz];
+}
+
+static bool d_cast_ray(const float* origin, const float* dir,
+                        const int* block_offset, const float* leaf_data,
+                        float* hit_t, float* hit_normal)
+{
+  float t_near, t_far;
+  if (!d_ray_box(origin, dir, &t_near, &t_far)) return false;
+
+  float inv_dir[3];
+  int   step[3];
+  for (int k = 0; k < 3; k++) {
+    inv_dir[k] = (fabsf(dir[k]) > 1e-8f) ? (1.0f / dir[k]) : 1e8f;
+    step[k]    = (dir[k] >= 0.0f) ? 1 : -1;
+  }
+
+  float entry[3];
+  for (int k = 0; k < 3; k++) {
+    entry[k] = origin[k] + t_near * dir[k];
+    if (entry[k] < 0.0f) entry[k] = 0.0f;
+    if (entry[k] > 1.0f - 1e-6f) entry[k] = 1.0f - 1e-6f;
+  }
+
+  int   bi[3];
+  float tMax[3], tDelta[3];
+  for (int k = 0; k < 3; k++) {
+    bi[k] = (int)(entry[k] / BLOCK_W);
+    if (bi[k] < 0) bi[k] = 0;
+    if (bi[k] >= GRID_DIM) bi[k] = GRID_DIM - 1;
+    float boundary = (step[k] > 0) ? (bi[k] + 1) * BLOCK_W
+                                   :  bi[k]      * BLOCK_W;
+    tMax[k]   = t_near + (boundary - entry[k]) * inv_dir[k];
+    tDelta[k] = fabsf(BLOCK_W * inv_dir[k]);
+  }
+
+  float t_block = t_near;
+
+  for (int s = 0; s < GRID_DIM * 3; s++) {
+    if (bi[0] < 0 || bi[0] >= GRID_DIM ||
+        bi[1] < 0 || bi[1] >= GRID_DIM ||
+        bi[2] < 0 || bi[2] >= GRID_DIM) break;
+
+    float t_next = tMax[0];
+    if (tMax[1] < t_next) t_next = tMax[1];
+    if (tMax[2] < t_next) t_next = tMax[2];
+    if (t_far   < t_next) t_next = t_far;
+
+    int idx = (bi[0] * GRID_DIM + bi[1]) * GRID_DIM + bi[2];
+    int off = block_offset[idx];
+
+    if (off >= 0) {
+      float ve[3];
+      for (int k = 0; k < 3; k++) {
+        ve[k] = origin[k] + t_block * dir[k];
+        if (ve[k] < 0.0f) ve[k] = 0.0f;
+        if (ve[k] > 1.0f - 1e-6f) ve[k] = 1.0f - 1e-6f;
+      }
+
+      float bo[3] = { bi[0] * BLOCK_W, bi[1] * BLOCK_W, bi[2] * BLOCK_W };
+      int   vi[3];
+      float vtMax[3], vtDelta[3];
+      for (int k = 0; k < 3; k++) {
+        float local = (ve[k] - bo[k]) / VOXEL_SIZE;
+        vi[k] = (int)local;
+        if (vi[k] < 0) vi[k] = 0;
+        if (vi[k] >= LEAF_DIM) vi[k] = LEAF_DIM - 1;
+        float vb = (step[k] > 0) ? (vi[k] + 1) * VOXEL_SIZE + bo[k]
+                                 :  vi[k]      * VOXEL_SIZE + bo[k];
+        vtMax[k]   = t_block + (vb - ve[k]) * inv_dir[k];
+        vtDelta[k] = fabsf(VOXEL_SIZE * inv_dir[k]);
+      }
+
+      int gv[3] = { bi[0] * LEAF_DIM + vi[0],
+                     bi[1] * LEAF_DIM + vi[1],
+                     bi[2] * LEAF_DIM + vi[2] };
+
+      const float* leaf_base = leaf_data + (size_t)off * LEAF_VOXELS;
+      float prev   = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+      float prev_t = t_block;
+
+      for (int vs = 0; vs < LEAF_DIM * 3; vs++) {
+        float cur_t;
+        if (vtMax[0] <= vtMax[1] && vtMax[0] <= vtMax[2]) {
+          cur_t = vtMax[0]; vi[0] += step[0]; gv[0] += step[0];
+          vtMax[0] += vtDelta[0];
+        } else if (vtMax[1] <= vtMax[2]) {
+          cur_t = vtMax[1]; vi[1] += step[1]; gv[1] += step[1];
+          vtMax[1] += vtDelta[1];
+        } else {
+          cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
+          vtMax[2] += vtDelta[2];
+        }
+        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+            vi[1] < 0 || vi[1] >= LEAF_DIM ||
+            vi[2] < 0 || vi[2] >= LEAF_DIM ||
+            cur_t > t_next) break;
+
+        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+
+        if (prev > 0.0f && cur <= 0.0f) {
+          float alpha = prev / (prev - cur);
+          *hit_t = prev_t + alpha * (cur_t - prev_t);
+
+          float nx = d_lookup_tsdf(block_offset, leaf_data, gv[0]+1, gv[1], gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0]-1, gv[1], gv[2]);
+          float ny = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]+1, gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]-1, gv[2]);
+          float nz = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]+1)
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]-1);
+          float nn2 = nx*nx + ny*ny + nz*nz;
+          if (nn2 > 1e-12f) { float inv_nn = 1.0f / sqrtf(nn2); nx *= inv_nn; ny *= inv_nn; nz *= inv_nn; }
+          else              { nx = 0; ny = 1; nz = 0; }
+          hit_normal[0] = nx; hit_normal[1] = ny; hit_normal[2] = nz;
+          return true;
+        }
+        prev   = cur;
+        prev_t = cur_t;
+      }
+    }
+
+    t_block = t_next;
+    if      (tMax[0] <= tMax[1] && tMax[0] <= tMax[2]) { bi[0] += step[0]; tMax[0] += tDelta[0]; }
+    else if (tMax[1] <= tMax[2])                       { bi[1] += step[1]; tMax[1] += tDelta[1]; }
+    else                                               { bi[2] += step[2]; tMax[2] += tDelta[2]; }
+  }
+  return false;
+}
+
+static inline void d_render_pixel(const Camera& cam, int px, int py,
+                                  const int* block_offset,
+                                  const float* leaf_data, float* image)
+{
+  float origin[3], dir[3];
+  d_generate_ray(cam, px, py, origin, dir);
+
+  float ht, hn[3];
+  const size_t o = 4 * ((size_t)py * cam.width + px);
+  if (d_cast_ray(origin, dir, block_offset, leaf_data, &ht, hn)) {
+    const float light[3] = { 0.57735f, 0.57735f, 0.57735f };
+    const float ndotl = hn[0]*light[0] + hn[1]*light[1] + hn[2]*light[2];
+    const float shade = 0.2f + 0.8f * ((ndotl > 0.0f) ? ndotl : 0.0f);
+    image[o+0] = shade; image[o+1] = shade;
+    image[o+2] = shade; image[o+3] = ht;
+  } else {
+    image[o+0] = BG_COLOR; image[o+1] = BG_COLOR;
+    image[o+2] = BG_COLOR; image[o+3] = 0.0f;
+  }
+}
+
+#pragma omp end declare target
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+  int num_spheres = 12, width = 1280, height = 720, reps = 100;
+  if (argc > 1) num_spheres = atoi(argv[1]);
+  if (argc > 2) width       = atoi(argv[2]);
+  if (argc > 3) height      = atoi(argv[3]);
+  if (argc > 4) reps        = atoi(argv[4]);
+  if (num_spheres > MAX_SPHERES) num_spheres = MAX_SPHERES;
+  if (num_spheres <= 0 || width <= 0 || height <= 0 || reps <= 0) {
+    fprintf(stderr, "Spheres, width, height, and reps must all be positive\n");
+    return 1;
+  }
+
+  printf("Spheres=%d  Image=%dx%d  Reps=%d\n", num_spheres, width, height, reps);
+
+  Sphere spheres[MAX_SPHERES];
+  generate_spheres(spheres, num_spheres);
+
+  SparseVolume vol;
+  build_volume(vol, spheres, num_spheres);
+
+  Camera cam;
+  setup_camera(width, height, cam);
+
+  const size_t npix = (size_t)width * height;
+
+  std::vector<float> ref(4 * npix, 0.0f);
+  reference_render(cam, vol.block_offset, vol.leaf_data.data(), ref.data());
+
+  int ref_hits = 0;
+  for (size_t i = 0; i < npix; i++)
+    if (ref[4 * i + 3] > 0.0f) ref_hits++;
+  printf("Reference: %d / %zu pixels hit a surface\n", ref_hits, npix);
+
+  const int   *h_block = vol.block_offset;
+  const float *h_leaf  = vol.leaf_data.data();
+
+  std::vector<float> gpu(4 * npix, 0.0f);
+  float *h_image = gpu.data();
+  bool pass = false;
+
+  const int num_teams = ((height + BLOCK_Y - 1) / BLOCK_Y) *
+                        ((width  + BLOCK_X - 1) / BLOCK_X);
+  const int thread_limit = BLOCK_X * BLOCK_Y;
+
+  #pragma omp target data map(to: h_block[0:GRID_BLOCKS]) \
+                           map(to: h_leaf[0:vol.num_active * LEAF_VOXELS]) \
+                           map(tofrom: h_image[0:4 * npix])
+  {
+    // warmup
+    for (int r = 0; r < reps; r++) {
+      #pragma omp target teams distribute parallel for collapse(2) \
+              num_teams(num_teams) thread_limit(thread_limit) nowait
+      for (int py = 0; py < height; py++)
+        for (int px = 0; px < width; px++)
+          d_render_pixel(cam, px, py, h_block, h_leaf, h_image);
+    }
+    #pragma omp taskwait
+
+    // verify
+    #pragma omp target update from(h_image[0:4 * npix])
+
+    int mismatches = 0;
+    for (size_t i = 0; i < npix; i++) {
+      bool pixel_mismatch = false;
+      for (int c = 0; c < 4; c++)
+        pixel_mismatch |= !close_enough(gpu[4 * i + c], ref[4 * i + c], 1e-2f);
+      mismatches += pixel_mismatch;
+    }
+
+    const int allowed = (int)(npix * 1e-4) + 1;
+    bool pass_result = (mismatches <= allowed);
+    printf("Raycast: %s\n", pass_result ? "PASS" : "FAIL");
+    if (mismatches > 0)
+      printf("  %d / %zu pixels differ (allowed %d)\n",
+             mismatches, npix, allowed);
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (int r = 0; r < reps; r++) {
+      #pragma omp target teams distribute parallel for collapse(2) \
+              num_teams(num_teams) thread_limit(thread_limit) nowait
+      for (int py = 0; py < height; py++)
+        for (int px = 0; px < width; px++)
+          d_render_pixel(cam, px, py, h_block, h_leaf, h_image);
+    }
+    #pragma omp taskwait
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+    printf("Average Raycast time: %.3f ms\n", ms / reps);
+
+    pass = pass_result;
+  }
+
+  return 0;
+}

--- a/src/svt-omp/main.cpp
+++ b/src/svt-omp/main.cpp
@@ -153,12 +153,19 @@ static bool d_cast_ray(const float* origin, const float* dir,
           cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
           vtMax[2] += vtDelta[2];
         }
-        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+        const bool left_leaf =
+            vi[0] < 0 || vi[0] >= LEAF_DIM ||
             vi[1] < 0 || vi[1] >= LEAF_DIM ||
-            vi[2] < 0 || vi[2] >= LEAF_DIM ||
-            cur_t > t_next) break;
+            vi[2] < 0 || vi[2] >= LEAF_DIM;
 
-        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+        // When the fine DDA steps out of the current leaf, gv[] already
+        // holds the global coordinate of the neighboring voxel. Sample it
+        // through the global lookup (which transparently resolves the
+        // neighboring block/leaf) so a surface crossing that straddles the
+        // leaf boundary is not silently discarded.
+        float cur = left_leaf
+            ? d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2])
+            : leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
 
         if (prev > 0.0f && cur <= 0.0f) {
           float alpha = prev / (prev - cur);
@@ -178,6 +185,8 @@ static bool d_cast_ray(const float* origin, const float* dir,
         }
         prev   = cur;
         prev_t = cur_t;
+
+        if (left_leaf || cur_t > t_next) break;
       }
     }
 

--- a/src/svt-omp/main.cpp
+++ b/src/svt-omp/main.cpp
@@ -277,12 +277,12 @@ int main(int argc, char** argv)
     // warmup
     for (int r = 0; r < reps; r++) {
       #pragma omp target teams distribute parallel for collapse(2) \
-              num_teams(num_teams) thread_limit(thread_limit) nowait
+              num_teams(num_teams) thread_limit(thread_limit) //nowait
       for (int py = 0; py < height; py++)
         for (int px = 0; px < width; px++)
           d_render_pixel(cam, px, py, h_block, h_leaf, h_image);
     }
-    #pragma omp taskwait
+    //#pragma omp taskwait
 
     // verify
     #pragma omp target update from(h_image[0:4 * npix])
@@ -305,12 +305,12 @@ int main(int argc, char** argv)
     auto t0 = std::chrono::high_resolution_clock::now();
     for (int r = 0; r < reps; r++) {
       #pragma omp target teams distribute parallel for collapse(2) \
-              num_teams(num_teams) thread_limit(thread_limit) nowait
+              num_teams(num_teams) thread_limit(thread_limit) //nowait
       for (int py = 0; py < height; py++)
         for (int px = 0; px < width; px++)
           d_render_pixel(cam, px, py, h_block, h_leaf, h_image);
     }
-    #pragma omp taskwait
+    //#pragma omp taskwait
     auto t1 = std::chrono::high_resolution_clock::now();
 
     float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();

--- a/src/svt-sycl/CMakeLists.txt
+++ b/src/svt-sycl/CMakeLists.txt
@@ -1,0 +1,11 @@
+# svt-sycl/CMakeLists.txt
+
+add_hecbench_benchmark(
+    NAME svt
+    MODEL sycl
+    SOURCES main.cpp
+    CATEGORIES simulation
+    TEST_ARGS 12 1280 720 100
+    TEST_REGEX "Raycast: PASS"
+    TEST_TIMEOUT 300
+)

--- a/src/svt-sycl/Makefile
+++ b/src/svt-sycl/Makefile
@@ -1,0 +1,82 @@
+#===============================================================================
+# User Options
+#===============================================================================
+
+# Compiler can be set below, or via environment variable
+CC        = icpx
+OPTIMIZE  = yes
+DEBUG     = no
+LAUNCHER  ?=
+
+GPU       = yes
+CUDA      = no
+CUDA_ARCH ?= sm_70
+HIP       = no
+HIP_ARCH  ?= gfx908
+#GCC_TOOLCHAIN = "/auto/software/gcc/x86_64/gcc-9.1.0/"
+
+#===============================================================================
+# Program name & source code list
+#===============================================================================
+
+program = main
+
+source = main.cpp
+
+obj = $(source:.cpp=.o)
+
+#===============================================================================
+# Sets Flags
+#===============================================================================
+
+# Standard Flags
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -I../svt-cuda \
+          -fsycl --gcc-toolchain=$(GCC_TOOLCHAIN)
+
+ifeq ($(VENDOR), AdaptiveCpp)
+    CFLAGS_TMP := $(CFLAGS)
+    CFLAGS = $(filter-out -fsycl, $(CFLAGS_TMP))
+endif
+
+# Linker Flags
+LDFLAGS =
+
+ifeq ($(CUDA), yes)
+  CFLAGS += -fsycl-targets=nvptx64-nvidia-cuda \
+            -Xsycl-target-backend --cuda-gpu-arch=$(CUDA_ARCH)
+endif
+
+ifeq ($(HIP), yes)
+  CFLAGS += -fsycl-targets=amdgcn-amd-amdhsa \
+	    -Xsycl-target-backend --offload-arch=$(HIP_ARCH)
+endif
+
+# Debug Flags
+ifeq ($(DEBUG),yes)
+  CFLAGS  += -g -DDEBUG
+  LDFLAGS += -g
+endif
+
+# Optimization Flags
+ifeq ($(OPTIMIZE),yes)
+  CFLAGS += -O3
+endif
+
+ifeq ($(GPU),yes)
+  CFLAGS +=-DUSE_GPU
+endif
+#===============================================================================
+# Targets to Build
+#===============================================================================
+
+$(program): $(obj) Makefile
+	$(CC) $(CFLAGS) $(obj) -o $@ $(LDFLAGS)
+
+%.o: %.cpp ../svt-cuda/reference.h Makefile
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(program) $(obj)
+
+run: $(program)
+	$(LAUNCHER) ./$(program) 12 1280 720 100

--- a/src/svt-sycl/Makefile
+++ b/src/svt-sycl/Makefile
@@ -79,4 +79,4 @@ clean:
 	rm -rf $(program) $(obj)
 
 run: $(program)
-	$(LAUNCHER) ./$(program) 12 1280 720 100
+	$(LAUNCHER) ./$(program) 12 1280 720 1000

--- a/src/svt-sycl/main.cpp
+++ b/src/svt-sycl/main.cpp
@@ -139,12 +139,19 @@ inline bool d_cast_ray(const float* origin, const float* dir,
           cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
           vtMax[2] += vtDelta[2];
         }
-        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+        const bool left_leaf =
+            vi[0] < 0 || vi[0] >= LEAF_DIM ||
             vi[1] < 0 || vi[1] >= LEAF_DIM ||
-            vi[2] < 0 || vi[2] >= LEAF_DIM ||
-            cur_t > t_next) break;
+            vi[2] < 0 || vi[2] >= LEAF_DIM;
 
-        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+        // When the fine DDA steps out of the current leaf, gv[] already
+        // holds the global coordinate of the neighboring voxel. Sample it
+        // through the global lookup (which transparently resolves the
+        // neighboring block/leaf) so a surface crossing that straddles the
+        // leaf boundary is not silently discarded.
+        float cur = left_leaf
+            ? d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2])
+            : leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
 
         if (prev > 0.0f && cur <= 0.0f) {
           float alpha = prev / (prev - cur);
@@ -164,6 +171,8 @@ inline bool d_cast_ray(const float* origin, const float* dir,
         }
         prev   = cur;
         prev_t = cur_t;
+
+        if (left_leaf || cur_t > t_next) break;
       }
     }
 

--- a/src/svt-sycl/main.cpp
+++ b/src/svt-sycl/main.cpp
@@ -1,0 +1,315 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <chrono>
+#include <vector>
+#include <sycl/sycl.hpp>
+
+#include "reference.h"
+
+inline void d_generate_ray(const Camera cam, int px, int py,
+                           float* origin, float* dir)
+{
+  const float aspect = (float)cam.width * cam.inv_height;
+  const float u = (2.0f * (px + 0.5f) * cam.inv_width  - 1.0f) *
+                  cam.fov_scale * aspect;
+  const float v = (2.0f * (py + 0.5f) * cam.inv_height - 1.0f) *
+                  cam.fov_scale;
+  for (int k = 0; k < 3; k++) {
+    origin[k] = cam.eye[k];
+    dir[k] = u * cam.right[k] + v * cam.up[k] + cam.forward[k];
+  }
+  float inv_dn = sycl::rsqrt(dir[0]*dir[0] + dir[1]*dir[1] + dir[2]*dir[2]);
+  for (int k = 0; k < 3; k++) dir[k] *= inv_dn;
+}
+
+inline bool d_ray_box(const float* origin, const float* dir,
+                      float* t_near, float* t_far)
+{
+  float tmin = -1e30f, tmax = 1e30f;
+  for (int k = 0; k < 3; k++) {
+    if (sycl::fabs(dir[k]) < 1e-8f) {
+      if (origin[k] < 0.0f || origin[k] > 1.0f) return false;
+    } else {
+      float inv = 1.0f / dir[k];
+      float t1 = -origin[k] * inv;
+      float t2 = (1.0f - origin[k]) * inv;
+      if (t1 > t2) { float tmp = t1; t1 = t2; t2 = tmp; }
+      tmin = sycl::fmax(tmin, t1);
+      tmax = sycl::fmin(tmax, t2);
+    }
+  }
+  *t_near = sycl::fmax(tmin, 0.0f);
+  *t_far  = tmax;
+  return *t_near < *t_far;
+}
+
+inline float d_lookup_tsdf(const int* block_offset, const float* leaf_data,
+                           int vx, int vy, int vz)
+{
+  if (vx < 0 || vx >= VOXEL_DIM ||
+      vy < 0 || vy >= VOXEL_DIM ||
+      vz < 0 || vz >= VOXEL_DIM) return 1.0f;
+
+  int bx = vx >> LEAF_LOG2, by = vy >> LEAF_LOG2, bz = vz >> LEAF_LOG2;
+  int bi = (bx * GRID_DIM + by) * GRID_DIM + bz;
+  int off = block_offset[bi];
+  if (off < 0) return 1.0f;
+
+  int lx = vx & LEAF_MASK, ly = vy & LEAF_MASK, lz = vz & LEAF_MASK;
+  return leaf_data[(size_t)off * LEAF_VOXELS +
+                   (lx * LEAF_DIM + ly) * LEAF_DIM + lz];
+}
+
+inline bool d_cast_ray(const float* origin, const float* dir,
+                       const int* block_offset, const float* leaf_data,
+                       float* hit_t, float* hit_normal)
+{
+  float t_near, t_far;
+  if (!d_ray_box(origin, dir, &t_near, &t_far)) return false;
+
+  float inv_dir[3];
+  int   step[3];
+  for (int k = 0; k < 3; k++) {
+    inv_dir[k] = (sycl::fabs(dir[k]) > 1e-8f) ? (1.0f / dir[k]) : 1e8f;
+    step[k]    = (dir[k] >= 0.0f) ? 1 : -1;
+  }
+
+  float entry[3];
+  for (int k = 0; k < 3; k++)
+    entry[k] = sycl::fmax(0.0f, sycl::fmin(origin[k] + t_near * dir[k], 1.0f - 1e-6f));
+
+  int   bi[3];
+  float tMax[3], tDelta[3];
+  for (int k = 0; k < 3; k++) {
+    bi[k] = sycl::min(GRID_DIM - 1, sycl::max(0, (int)(entry[k] / BLOCK_W)));
+    float boundary = (step[k] > 0) ? (bi[k] + 1) * BLOCK_W
+                                   :  bi[k]      * BLOCK_W;
+    tMax[k]   = t_near + (boundary - entry[k]) * inv_dir[k];
+    tDelta[k] = sycl::fabs(BLOCK_W * inv_dir[k]);
+  }
+
+  float t_block = t_near;
+
+  for (int s = 0; s < GRID_DIM * 3; s++) {
+    if (bi[0] < 0 || bi[0] >= GRID_DIM ||
+        bi[1] < 0 || bi[1] >= GRID_DIM ||
+        bi[2] < 0 || bi[2] >= GRID_DIM) break;
+
+    float t_next = sycl::fmin(sycl::fmin(tMax[0], tMax[1]),
+                              sycl::fmin(tMax[2], t_far));
+
+    int idx = (bi[0] * GRID_DIM + bi[1]) * GRID_DIM + bi[2];
+    int off = block_offset[idx];
+
+    if (off >= 0) {
+      float ve[3];
+      for (int k = 0; k < 3; k++)
+        ve[k] = sycl::fmax(0.0f, sycl::fmin(origin[k] + t_block * dir[k], 1.0f - 1e-6f));
+
+      float bo[3] = { bi[0] * BLOCK_W, bi[1] * BLOCK_W, bi[2] * BLOCK_W };
+      int   vi[3];
+      float vtMax[3], vtDelta[3];
+      for (int k = 0; k < 3; k++) {
+        float local = (ve[k] - bo[k]) / VOXEL_SIZE;
+        vi[k] = sycl::min(LEAF_DIM - 1, sycl::max(0, (int)local));
+        float vb = (step[k] > 0) ? (vi[k] + 1) * VOXEL_SIZE + bo[k]
+                                 :  vi[k]      * VOXEL_SIZE + bo[k];
+        vtMax[k]   = t_block + (vb - ve[k]) * inv_dir[k];
+        vtDelta[k] = sycl::fabs(VOXEL_SIZE * inv_dir[k]);
+      }
+
+      int gv[3] = { bi[0] * LEAF_DIM + vi[0],
+                     bi[1] * LEAF_DIM + vi[1],
+                     bi[2] * LEAF_DIM + vi[2] };
+
+      const float* leaf_base = leaf_data + (size_t)off * LEAF_VOXELS;
+      float prev   = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+      float prev_t = t_block;
+
+      for (int vs = 0; vs < LEAF_DIM * 3; vs++) {
+        float cur_t;
+        if (vtMax[0] <= vtMax[1] && vtMax[0] <= vtMax[2]) {
+          cur_t = vtMax[0]; vi[0] += step[0]; gv[0] += step[0];
+          vtMax[0] += vtDelta[0];
+        } else if (vtMax[1] <= vtMax[2]) {
+          cur_t = vtMax[1]; vi[1] += step[1]; gv[1] += step[1];
+          vtMax[1] += vtDelta[1];
+        } else {
+          cur_t = vtMax[2]; vi[2] += step[2]; gv[2] += step[2];
+          vtMax[2] += vtDelta[2];
+        }
+        if (vi[0] < 0 || vi[0] >= LEAF_DIM ||
+            vi[1] < 0 || vi[1] >= LEAF_DIM ||
+            vi[2] < 0 || vi[2] >= LEAF_DIM ||
+            cur_t > t_next) break;
+
+        float cur = leaf_base[(vi[0] * LEAF_DIM + vi[1]) * LEAF_DIM + vi[2]];
+
+        if (prev > 0.0f && cur <= 0.0f) {
+          float alpha = prev / (prev - cur);
+          *hit_t = prev_t + alpha * (cur_t - prev_t);
+
+          float nx = d_lookup_tsdf(block_offset, leaf_data, gv[0]+1, gv[1], gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0]-1, gv[1], gv[2]);
+          float ny = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]+1, gv[2])
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1]-1, gv[2]);
+          float nz = d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]+1)
+                   - d_lookup_tsdf(block_offset, leaf_data, gv[0], gv[1], gv[2]-1);
+          float nn2 = nx*nx + ny*ny + nz*nz;
+          if (nn2 > 1e-12f) { float inv_nn = sycl::rsqrt(nn2); nx *= inv_nn; ny *= inv_nn; nz *= inv_nn; }
+          else              { nx = 0; ny = 1; nz = 0; }
+          hit_normal[0] = nx; hit_normal[1] = ny; hit_normal[2] = nz;
+          return true;
+        }
+        prev   = cur;
+        prev_t = cur_t;
+      }
+    }
+
+    t_block = t_next;
+    if      (tMax[0] <= tMax[1] && tMax[0] <= tMax[2]) { bi[0] += step[0]; tMax[0] += tDelta[0]; }
+    else if (tMax[1] <= tMax[2])                       { bi[1] += step[1]; tMax[1] += tDelta[1]; }
+    else                                               { bi[2] += step[2]; tMax[2] += tDelta[2]; }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+static int run(int argc, char** argv)
+{
+  int num_spheres = 12, width = 1280, height = 720, reps = 100;
+  if (argc > 1) num_spheres = atoi(argv[1]);
+  if (argc > 2) width       = atoi(argv[2]);
+  if (argc > 3) height      = atoi(argv[3]);
+  if (argc > 4) reps        = atoi(argv[4]);
+  if (num_spheres > MAX_SPHERES) num_spheres = MAX_SPHERES;
+  if (num_spheres <= 0 || width <= 0 || height <= 0 || reps <= 0) {
+    fprintf(stderr, "Spheres, width, height, and reps must all be positive\n");
+    return 1;
+  }
+
+  printf("Spheres=%d  Image=%dx%d  Reps=%d\n", num_spheres, width, height, reps);
+
+  Sphere spheres[MAX_SPHERES];
+  generate_spheres(spheres, num_spheres);
+
+  SparseVolume vol;
+  build_volume(vol, spheres, num_spheres);
+
+  Camera cam;
+  setup_camera(width, height, cam);
+
+  const size_t npix = (size_t)width * height;
+
+  std::vector<float> ref(4 * npix, 0.0f);
+  reference_render(cam, vol.block_offset, vol.leaf_data.data(), ref.data());
+
+  int ref_hits = 0;
+  for (size_t i = 0; i < npix; i++)
+    if (ref[4 * i + 3] > 0.0f) ref_hits++;
+  printf("Reference: %d / %zu pixels hit a surface\n", ref_hits, npix);
+
+#ifdef USE_GPU
+  sycl::queue q(sycl::gpu_selector_v, sycl::property::queue::in_order());
+#else
+  sycl::queue q(sycl::cpu_selector_v, sycl::property::queue::in_order());
+#endif
+
+  int   *d_block = sycl::malloc_device<int>(GRID_BLOCKS, q);
+  float *d_leaf  = sycl::malloc_device<float>((size_t)vol.num_active * LEAF_VOXELS, q);
+  float *d_image = sycl::malloc_device<float>(4 * npix, q);
+  if (d_block == nullptr || d_leaf == nullptr || d_image == nullptr) {
+    fprintf(stderr, "Failed to allocate SYCL device buffers\n");
+    sycl::free(d_block, q);
+    sycl::free(d_leaf, q);
+    sycl::free(d_image, q);
+    return 1;
+  }
+
+  q.memcpy(d_block, vol.block_offset, sizeof(int) * GRID_BLOCKS);
+  q.memcpy(d_leaf, vol.leaf_data.data(),
+           sizeof(float) * vol.num_active * LEAF_VOXELS);
+
+  sycl::range<2> global(((size_t)height + BLOCK_Y - 1) / BLOCK_Y * BLOCK_Y,
+                        ((size_t)width  + BLOCK_X - 1) / BLOCK_X * BLOCK_X);
+  sycl::range<2> local(BLOCK_Y, BLOCK_X);
+
+  auto launch = [&]() {
+    q.submit([&](sycl::handler& h) {
+      h.parallel_for(sycl::nd_range<2>(global, local),
+        [=](sycl::nd_item<2> item) {
+          int px = item.get_global_id(1);
+          int py = item.get_global_id(0);
+          if (px >= cam.width || py >= cam.height) return;
+
+          float origin[3], dir[3];
+          d_generate_ray(cam, px, py, origin, dir);
+
+          float ht, hn[3];
+          size_t o = 4 * ((size_t)py * cam.width + px);
+
+          if (d_cast_ray(origin, dir, d_block, d_leaf, &ht, hn)) {
+            const float light[3] = { 0.57735f, 0.57735f, 0.57735f };
+            float ndotl = hn[0]*light[0] + hn[1]*light[1] + hn[2]*light[2];
+            float shade = 0.2f + 0.8f * sycl::fmax(0.0f, ndotl);
+            d_image[o+0] = shade; d_image[o+1] = shade;
+            d_image[o+2] = shade; d_image[o+3] = ht;
+          } else {
+            d_image[o+0] = BG_COLOR; d_image[o+1] = BG_COLOR;
+            d_image[o+2] = BG_COLOR; d_image[o+3] = 0.0f;
+          }
+        });
+    });
+  };
+
+  // warmup
+  for (int r = 0; r < reps; r++) launch();
+  q.wait_and_throw();
+
+  // verify
+  std::vector<float> gpu(4 * npix);
+  q.memcpy(gpu.data(), d_image, sizeof(float) * 4 * npix).wait_and_throw();
+
+  int mismatches = 0;
+  for (size_t i = 0; i < npix; i++) {
+    bool pixel_mismatch = false;
+    for (int c = 0; c < 4; c++)
+      pixel_mismatch |= !close_enough(gpu[4 * i + c], ref[4 * i + c], 1e-2f);
+    mismatches += pixel_mismatch;
+  }
+
+  const int allowed = (int)(npix * 1e-4) + 1;
+  bool pass = (mismatches <= allowed);
+  printf("Raycast: %s\n", pass ? "PASS" : "FAIL");
+  if (mismatches > 0)
+    printf("  %d / %zu pixels differ (allowed %d)\n",
+           mismatches, npix, allowed);
+
+  auto t0 = std::chrono::high_resolution_clock::now();
+  for (int r = 0; r < reps; r++) launch();
+  q.wait_and_throw();
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  float ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+  printf("Average Raycast time: %.3f ms\n", ms / reps);
+
+  sycl::free(d_block, q);
+  sycl::free(d_leaf,  q);
+  sycl::free(d_image, q);
+
+  return 0;
+}
+
+int main(int argc, char** argv)
+{
+  try {
+    return run(argc, argv);
+  } catch (const sycl::exception& e) {
+    fprintf(stderr, "SYCL error: %s\n", e.what());
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained sparse volume traversal benchmark with a CPU reference
- provide CUDA, HIP, SYCL, and OpenMP target-offload implementations
- register SVT in CMake and document it in the benchmark catalog


Made with [Cursor](https://cursor.com)