### PR TITLE
[sheath-hip] Drop save-temps from standard flags

### DIFF
--- a/src/sheath-hip/Makefile
+++ b/src/sheath-hip/Makefile
@@ -23,7 +23,7 @@ obj = $(source:.cu=.o)
 #===============================================================================
 
 # Standard Flags
-CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall -save-temps
+CFLAGS := $(EXTRA_CFLAGS) -std=c++17 -Wall
 
 # Linker Flags
 LDFLAGS = 


### PR DESCRIPTION
`-save-temps` is a debug flag that keeps temporary files generated by the compiler during the different compilation steps rather than removing them. I didn't observe any other benchmark containing this as a standard flag, so I think the right call is to drop it here too.