### PR TITLE
[leukocyte-hip] Quote CC when passed to a sub-make

### DIFF
--- a/src/leukocyte-hip/Makefile
+++ b/src/leukocyte-hip/Makefile
@@ -59,7 +59,7 @@ track_ellipse_gpu.o: track_ellipse_gpu.c track_ellipse.h kernel_IMGVF.h
 
 # Cleanup everything, then clean everything except the static library
 $(MATRIX_DIR)/meschach.a:
-	cd $(MATRIX_DIR); make cleanup; make all CC=$(CC); make clean
+	cd $(MATRIX_DIR); make cleanup; make all CC="$(CC)"; make clean
 
 run: main
 	$(LAUNCHER) ./main ../data/leukocyte/testfile.avi 100


### PR DESCRIPTION
Passing `$(CC)` to a sub-make unquoted is fragile: it only works when CC is a single word (e.g. hipcc), but it breaks if it is multiple words (e.g. hipcc --offload-arch=$(ARCH)). In the latter case, the extra words would be split off, and the sub-make would parse them as separate goals instead of as part of `CC`.