### PR TITLE
Fix out-of-bounds task queue access in tqs

### DIFF
--- a/src/tqs-cuda/kernel.cu
+++ b/src/tqs-cuda/kernel.cu
@@ -53,8 +53,10 @@ void TaskQueue_gpu(const task_t *__restrict__ queue,
   // Fetch task
   if(tid == 0) {
     next = atomicAdd(consumed, 1);
-    t->id = queue[next].id;
-    t->op = queue[next].op;
+    if(next < gpuQueueSize) {
+      t->id = queue[next].id;
+      t->op = queue[next].op;
+    }
   }
   __syncthreads();
   while(next < gpuQueueSize) {
@@ -78,8 +80,10 @@ void TaskQueue_gpu(const task_t *__restrict__ queue,
     if(tid == 0) {
       next = atomicAdd(consumed, 1);
       // Fetch task
-      t->id = queue[next].id;
-      t->op = queue[next].op;
+      if(next < gpuQueueSize) {
+        t->id = queue[next].id;
+        t->op = queue[next].op;
+      }
     }
     __syncthreads();
   }


### PR DESCRIPTION
This patch fixes an out-of-bounds read in the CUDA implementation of tqs.

The kernel obtains task indices using atomicAdd(consumed, 1). Previously, the kernel immediately read queue[next].id and queue[next].op before checking whether next was still within gpuQueueSize. When the task queue is exhausted, next can be equal to or larger than gpuQueueSize, causing an out-of-bounds read.

The fix guards both task-fetch sites and only reads queue[next] when next < gpuQueueSize. The existing while condition still controls whether the block processes the fetched task.

  Validation:
  - make clean && make ARCH=sm_86
  - ./main -r 1 -w 0 -f input/patternsNP100NB512FB25.txt
  - compute-sanitizer --tool memcheck ./main -r 1 -w 0 -f input/patternsNP100NB512FB25.txt

  The benchmark passes and Compute Sanitizer reports 0 errors.